### PR TITLE
fix: zbus notification issue fix

### DIFF
--- a/services/server/zbus/src/interfaces/bluetooth_interface.rs
+++ b/services/server/zbus/src/interfaces/bluetooth_interface.rs
@@ -63,7 +63,7 @@ pub struct BluetoothAdapterInfoListResponse {
     pub bluetooth_adapter_info: Vec<BluetoothAdapterInfoResponse>,
 }
 
-#[derive(DeserializeDict, SerializeDict, Type)]
+#[derive(DeserializeDict, SerializeDict, Type, Debug)]
 // `Type` treats `BluetoothNotificationEvent` is an alias for `a{sv}`.
 #[zvariant(signature = "a{sv}")]
 pub struct BluetoothNotificationEvent {
@@ -257,11 +257,6 @@ pub async fn bluetooth_event_notification_stream(
                     },
                 )
                 .await?;
-
-            println!(
-                "Bluetooth status: {}, Connected: {}",
-                is_enable, is_connected,
-            );
 
             previous_is_enable = Some(is_enable);
             previous_is_connected = Some(is_connected);

--- a/services/server/zbus/src/interfaces/mod.rs
+++ b/services/server/zbus/src/interfaces/mod.rs
@@ -1,17 +1,19 @@
 mod bluetooth_interface;
-pub use bluetooth_interface::BluetoothBusInterface;
+pub use bluetooth_interface::{bluetooth_event_notification_stream, BluetoothBusInterface};
 
 mod wireless_interface;
 pub use wireless_interface::{
-    KnownNetworkListResponse, KnownNetworkResponse, WirelessBusInterface, WirelessInfoResponse,
-    WirelessScanListResponse,
+    wireless_event_notification_stream, KnownNetworkListResponse, KnownNetworkResponse,
+    WirelessBusInterface, WirelessInfoResponse, WirelessScanListResponse,
 };
 
 mod power_interface;
-pub use power_interface::PowerBusInterface;
+pub use power_interface::{power_event_notification_stream, PowerBusInterface};
 
 mod display_interface;
 pub use display_interface::DisplayBusInterface;
 
 mod host_metrics;
-pub use host_metrics::{HostMetricsBusInterface, MemoryInfoResponse};
+pub use host_metrics::{
+    host_metrics_event_notification_stream, HostMetricsBusInterface, MemoryInfoResponse,
+};

--- a/services/server/zbus/src/interfaces/power_interface.rs
+++ b/services/server/zbus/src/interfaces/power_interface.rs
@@ -217,12 +217,6 @@ pub async fn power_event_notification_stream(
                 )
                 .await?;
 
-            // println notification
-            println!(
-                "Battery Status: {}, Battery Percentage: {}%",
-                current_status, current_percentage
-            );
-
             // Update the previous values to the current ones
             previous_percentage = Some(current_percentage);
             previous_status = Some(current_status);

--- a/services/server/zbus/src/interfaces/power_interface.rs
+++ b/services/server/zbus/src/interfaces/power_interface.rs
@@ -79,41 +79,6 @@ impl PowerBusInterface {
         Ok(percentage)
     }
 
-    // events for all signals to be emitted notification
-    pub async fn send_notification_stream(&self) -> Result<(), ZbusError> {
-        let mut interval = time::interval(Duration::from_secs(1));
-        let mut previous_percentage: Option<f32> = None;
-        let mut previous_status: Option<String> = None;
-
-        loop {
-            interval.tick().await;
-            let power = Power::new();
-            let current_percentage = power.get_battery_percentage();
-            let current_status = power.get_battery_status();
-            let ctxt =
-                SignalContext::new(&Connection::system().await?, "/org/mechanix/services/Power")?;
-
-            // Check if the current percentage has changed from the previous percentage
-            if previous_percentage != Some(current_percentage)
-                || previous_status != Some(current_status.clone())
-            {
-                // If there's a change, emit the notification signal
-                self.notification(
-                    &ctxt,
-                    PowerNotificationEvent {
-                        status: current_status.clone(),
-                        percentage: current_percentage,
-                    },
-                )
-                .await?;
-
-                // Update the previous values to the current ones
-                previous_percentage = Some(current_percentage);
-                previous_status = Some(current_status);
-            }
-        }
-    }
-
     //set cpu governor
     pub async fn set_cpu_governor(&self, governor: &str) -> Result<(), ZbusError> {
         let power = Power::new();
@@ -219,4 +184,48 @@ async fn authorized() -> Result<bool, Box<dyn std::error::Error>> {
         )
         .await?;
     Ok(result.is_authorized)
+}
+
+// events for all signals to be emitted notification
+pub async fn power_event_notification_stream(
+    power_bus: &PowerBusInterface,
+    conn: &zbus::Connection,
+) -> Result<(), ZbusError> {
+    let mut interval = time::interval(Duration::from_secs(1));
+    let mut previous_percentage: Option<f32> = None;
+    let mut previous_status: Option<String> = None;
+
+    loop {
+        interval.tick().await;
+        let power = Power::new();
+        let current_percentage = power.get_battery_percentage();
+        let current_status = power.get_battery_status();
+        let ctxt = SignalContext::new(conn, "/org/mechanix/services/Power")?;
+
+        // Check if the current percentage has changed from the previous percentage
+        if previous_percentage != Some(current_percentage)
+            || previous_status != Some(current_status.clone())
+        {
+            // If there's a change, emit the notification signal
+            power_bus
+                .notification(
+                    &ctxt,
+                    PowerNotificationEvent {
+                        status: current_status.clone(),
+                        percentage: current_percentage,
+                    },
+                )
+                .await?;
+
+            // println notification
+            println!(
+                "Battery Status: {}, Battery Percentage: {}%",
+                current_status, current_percentage
+            );
+
+            // Update the previous values to the current ones
+            previous_percentage = Some(current_percentage);
+            previous_status = Some(current_status);
+        }
+    }
 }


### PR DESCRIPTION
- we need to use the same bus to trigger the notification what we've created initially. 
- in this fix new creation of bus instance is avoided 