### PR TITLE
feat(camera-app): Snapshot will get saved in the `~/Pictures` directory.

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -6,10 +6,10 @@ members = [
 default-members = ["settings-app", "camera",  "files"]
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 authors = [
    "Sweta <swetar@mechasystems.com>", 
-   "Naman <namana-mecha@mechasystems.com>",
+   "Naman <namana@mechasystems.com>",
    "Minesh <mineshp-mecha@mechasystems.com>",
 ]
 edition = "2021"

--- a/apps/camera/Cargo.toml
+++ b/apps/camera/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1.0.217"
 serde_yaml = "0.9.34"
 dirs = "5.0.1"
 const_format = "0.2.34"
+chrono = "0.4.39"
 
 [package.metadata.deb]
 name = "mechanix-camera"

--- a/apps/settings-app/src/screens/settings_menu/settings_screen.rs
+++ b/apps/settings-app/src/screens/settings_menu/settings_screen.rs
@@ -353,7 +353,7 @@ impl Component for SettingsScreen {
         );
 
         list_items = list_items.push(network_div);
-        list_items = list_items.push(bluetooth_div);
+        // list_items = list_items.push(bluetooth_div);
         list_items = list_items.push(display_div);
         // list_items = list_items.push(appearance_div);
         list_items = list_items.push(battery_div);


### PR DESCRIPTION
# Objective

Fixes #177 

## Solution

- After taking the photo the app will save the photo in the `~/Pictures` directory.
- Pictures are saved in the format `Snapshot_Ymd_HMS.jpg`

## Showcase
- We get the local time using the `chrono` crate and the use the `format` function to correctly name the file. 
- We get the home directory using the environment variable `HOME` and create a Pictures directory in the home folder if it doesn't exist. 
- Then save the snapshot with the filename in the pictures directory.

The following code is added to `contexts::camera::save_frame()`

<details>
  <summary>Click to view code</summary>

```rust
let now = chrono::Local::now();
let formatted_time = now.format("%Y%m%d_%H%M%S").to_string();
let mut pictures_dir = std::path::PathBuf::from(
    std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string()),
);
pictures_dir.push("Pictures");

if !pictures_dir.exists() {
    std::fs::create_dir_all(&pictures_dir)
        .expect("Couldn't create directory `Pictures`");
}

let filename = format!("Snapshot_{}.jpg", formatted_time);
let filepath = pictures_dir.join(&filename);
frame.save(filepath).unwrap();
```

</details>