### PR TITLE
fix(settings-app): network status & delete network action

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 default-members = ["settings-app", "camera",  "files"]
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.17"
 authors = [
    "Sweta <swetar@mechasystems.com>", 
    "Naman <namana-mecha@mechasystems.com>",


### PR DESCRIPTION
Settings App update
-----------------------------
1. Network status(connecting, connected, saved) view fix
2. For connected/saved network, on click of delete icon it will forget network (connection_proxy.delete() used)

- Note: 
  - connection_proxy.delete() : remove network settings permanently, need to re-enter credentials
  - device_proxy.disconnect() : keeps network settings & disconnect network temporarily (might use in future)