### PR TITLE
fix(shell workflow): fix shell workflow build error by updating rust version to 1.81

### DIFF
--- a/.github/workflows/build-shell-aarch64.yml
+++ b/.github/workflows/build-shell-aarch64.yml
@@ -92,10 +92,10 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.75.0
+      - name: Install Rust 1.81.0
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          rustup default 1.75.0
+          rustup default 1.81.0
 
       - name: Install cargo-deb
         run: cargo install cargo-deb


### PR DESCRIPTION
1. fix shell workflow build error by updating rust version to 1.81