### PR TITLE
adds devShells for compiling on NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = { nixpkgs, systems, ... }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+      pkgsFor = nixpkgs.legacyPackages;
+    in {
+      devShells = eachSystem (system:
+        let
+          pkgs = pkgsFor.${system};
+          commonPkgs = with pkgs;[
+              libxkbcommon
+              cargo
+              rustc
+              wayland
+              pkg-config
+              glib
+          ];
+          # for the files application in apps/files
+          fonts = with pkgs; [
+            noto-fonts
+            noto-fonts-emoji
+            dejavu_fonts
+            freefont_ttf
+          ];
+          dlopenLibraries = with pkgs; [
+            libxkbcommon
+            # GPU backend
+            vulkan-loader
+            # libGL
+
+            ## required specifically by settings application
+            libllvm
+            libclang
+            llvmPackages.libclang
+
+            # required by launcher 
+            libpulseaudio
+          ];
+        in {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              gst_all_1.gstreamer
+              # Common plugins like "filesrc" to combine within e.g. gst-launch
+              gst_all_1.gst-plugins-base
+              # Some one might need these Specialized plugins separated by quality
+              # gst_all_1.gst-plugins-good
+              # gst_all_1.gst-plugins-bad
+              # gst_all_1.gst-plugins-ugly
+              # # Plugins to reuse ffmpeg to play almost every video format
+              # gst_all_1.gst-libav
+              # # Support the Video Audio (Hardware) Acceleration API
+              # gst_all_1.gst-vaapi
+
+              ## required specifically by settings application
+              dbus
+              pam
+              rustPlatform.bindgenHook
+              protobuf
+
+            ]++ dlopenLibraries ++ commonPkgs ++ fonts;
+
+            env.RUSTFLAGS = "-C link-arg=-Wl,-rpath,${nixpkgs.lib.makeLibraryPath dlopenLibraries}";
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
+          };
+        });
+    };
+}


### PR DESCRIPTION
> Built these locally, realized these need a lot of dependencies. This PR:

Adds a flake.nix with devShells, running `nix develop` on the directory containing flake.nix launches a temporary shell with dependencies and environment variables required to compile all these applications on NixOS.

- https://nixos.wiki/wiki/Flakes
- https://ebzzry.com/en/flakes/
- https://nix.dev/concepts/flakes