### PR TITLE
feat(mxsearch): add app actions search

### DIFF
--- a/mxsearch/Cargo.toml
+++ b/mxsearch/Cargo.toml
@@ -16,4 +16,5 @@ thiserror = "2.0.12"
 toml = "0.9.2"
 apps = { path = "apps" }
 files = { path = "files" }
+app_actions = { path = "app_actions" }
 

--- a/mxsearch/README.md
+++ b/mxsearch/README.md
@@ -55,28 +55,48 @@ sudo sysctl -w fs.inotify.max_user_watches=1048576
 
 ### ⚙️ App Actions Search
 
-**Overview**  
+## Overview
+
 This service indexes configuration schemas into a Tantivy search index.
 Each config file is parsed and indexed with its metadata and nested action sections.
 It maintains data consistency by using checksum validation to avoid unnecessary re-indexing.
 
-## Features
+- Applications installed on the system register their **App Actions** to **mxsearch**.
+- This allows mxsearch to return App Actions as part of search results.
+- App Actions are stored as **TOML** files inside the directory:  
+  `/usr/share/mxsearch/actions`
 
-- Provides full-text and exact matching search capabilities for app actions for quick lookup.
-- Parses configuration schemas containing global data and nested action blocks.
-- Indexes each action block as a separate document with searchable fields.
-- Stores checksums for indexed files to detect changes for re-indexing.
-- Supports fast searching by file path to find existing indexed documents.
-- Uses a structured Tantivy schema optimized for configuration elements.
+## Example: Settings App Actions file
 
-## Searching Functionality for App Actions
+```toml
+name = "Settings"
+icon = "path/to/icon.png"
+description = "Manage system settings"
+exec = "mechanix-settings"
 
-You can perform powerful searches over your indexed app actions, leveraging Tantivy’s full-text search and exact
-matching:
+[EnableWifi]
+action = "Enable WiFi"
+description = "Enable wireless network"
+arg = { path = "network" }
 
-- **Search by action name or description:** Quickly find actions like "Enable WiFi" or any keyword in descriptions.
-- **Filter by section names:** Narrow down results to specific config sections (like `[EnableBluetooth]`).
-- **Lookup by argument values:** For example, find all actions where the argument `path` equals `"network"`.
+[Files]
+Action = "Search Files"
+Description = "Search by file name"
+Arg = { path = "%KEYWORD%" }
+```
+
+File path: `/usr/share/mxsearch/actions/org.mechanix.Settings.toml`
+
+- `%KEYWORD%` is a reserved placeholder that passes the user's search key to the app action.
+
+## Functionality
+
+- mxsearch indexes the `/usr/share/mxsearch/actions` directory.
+- It uses checksums to detect changes and refresh the index accordingly.
+- Endpoints include:
+    - Search App Actions
+
+---
 
 ## Workflow
 

--- a/mxsearch/README.md
+++ b/mxsearch/README.md
@@ -53,6 +53,41 @@ sudo sysctl -w fs.inotify.max_user_watches=1048576
     - We can configure the allowed extensions to be indexed.
     - We can configure the max size of the file content to be indexed.
 
+### ⚙️ App Actions Search
+
+**Overview**  
+This service indexes configuration schemas into a Tantivy search index.
+Each config file is parsed and indexed with its metadata and nested action sections.
+It maintains data consistency by using checksum validation to avoid unnecessary re-indexing.
+
+## Features
+
+- Provides full-text and exact matching search capabilities for app actions for quick lookup.
+- Parses configuration schemas containing global data and nested action blocks.
+- Indexes each action block as a separate document with searchable fields.
+- Stores checksums for indexed files to detect changes for re-indexing.
+- Supports fast searching by file path to find existing indexed documents.
+- Uses a structured Tantivy schema optimized for configuration elements.
+
+## Searching Functionality for App Actions
+
+You can perform powerful searches over your indexed app actions, leveraging Tantivy’s full-text search and exact
+matching:
+
+- **Search by action name or description:** Quickly find actions like "Enable WiFi" or any keyword in descriptions.
+- **Filter by section names:** Narrow down results to specific config sections (like `[EnableBluetooth]`).
+- **Lookup by argument values:** For example, find all actions where the argument `path` equals `"network"`.
+
+## Workflow
+
+### On Service Start
+
+1. Compute the checksum of the config file.
+2. Search the Tantivy index for documents matching the file path.
+3. Compare stored checksum(s) with the newly computed checksum.
+4. If checksum matches, no action needed (index is current).
+5. If not, parse the config file and re-index all action documents with the updated checksum.
+
 Settings file example:
 
 ```toml
@@ -85,13 +120,15 @@ searchable_fields = [
     "content"
 ]
 allowed_extensions = ["txt", "yaml", "rtf", "xml", "toml"]
+[app_actions]
+enable_search = true
+index_dir = ".config/mxsearch/index/app_actions"
+schema_dir = "/usr/share/mxsearch/actions"
+search_limit = 15
+searchable_fields = [
+    "action",
+]
 ```
-
-- **Configurable File Search Service**
-    - Enable/disable file search.
-    - Define the path to the files you want to include in the search.
-
----
 
 ## 🛠️ Configuration Example (`config.toml`)
 

--- a/mxsearch/app_actions/Cargo.toml
+++ b/mxsearch/app_actions/Cargo.toml
@@ -14,3 +14,4 @@ futures = "0.3.31"
 crc32fast = "1.5.0"
 serde = { version = "1.0.219", features = ["derive"] }
 zbus = "3.14.1"
+toml = "0.9.5"

--- a/mxsearch/app_actions/Cargo.toml
+++ b/mxsearch/app_actions/Cargo.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tokio = { version = "1.46.1", features = ["full"] }
+notify = "8.1.0"
+dirs = "6.0.0"
+anyhow = "1.0.98"
+tantivy = { git = "https://github.com/quickwit-oss/tantivy.git", branch = "main" }
+log = "0.4.27"
+futures = "0.3.31"
+crc32fast = "1.5.0"
+serde = { version = "1.0.219", features = ["derive"] }
+zbus = "3.14.1"

--- a/mxsearch/app_actions/src/lib.rs
+++ b/mxsearch/app_actions/src/lib.rs
@@ -4,7 +4,7 @@ pub mod service;
 mod utils;
 
 pub use crate::service::AppActionsService;
-
+pub use crate::service::AppActions;
 #[derive(Debug, Deserialize, Clone)]
 pub struct AppActionsConfig {
     pub enable_search: bool,

--- a/mxsearch/app_actions/src/lib.rs
+++ b/mxsearch/app_actions/src/lib.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
 pub mod service;
+mod utils;
+
 pub use crate::service::AppActionsService;
 
 #[derive(Debug, Deserialize, Clone)]

--- a/mxsearch/app_actions/src/lib.rs
+++ b/mxsearch/app_actions/src/lib.rs
@@ -1,14 +1,13 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+use serde::Deserialize;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub mod service;
+pub use crate::service::AppActionsService;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+#[derive(Debug, Deserialize, Clone)]
+pub struct AppActionsConfig {
+    pub enable_search: bool,
+    pub index_dir: String,
+    pub schema_dir: String,
+    pub search_limit: usize,
+    searchable_fields: Vec<String>,
 }

--- a/mxsearch/app_actions/src/service.rs
+++ b/mxsearch/app_actions/src/service.rs
@@ -1,0 +1,525 @@
+use log::{debug, error, info, warn};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use std::fs::read_dir;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crate::AppActionsConfig;
+use tantivy::query::TermQuery;
+use tantivy::schema::{Field, IndexRecordOption, Value, STRING};
+use tantivy::{
+    collector::TopDocs, doc, query::QueryParser, schema::{Schema, STORED, TEXT}, Document, Index,
+    IndexReader,
+    IndexWriter,
+    TantivyDocument,
+    Term,
+};
+use tokio::{sync::mpsc, task::JoinHandle, time};
+use zbus::zvariant::{DeserializeDict, SerializeDict, Type};
+
+#[derive(Type, SerializeDict, DeserializeDict, Debug, Default, Clone)]
+#[zvariant(signature = "dict")]
+pub struct AppInfo {
+    pub type_: String,
+    pub name: String,
+    pub generic_name: String,
+    pub keywords: Vec<String>,
+    pub comment: String,
+    pub icon: String,
+    pub categories: Vec<String>,
+    pub exec: String,
+    pub path: String,
+    pub score: f32,
+}
+/// Public entry point for the app search service.
+
+#[derive()]
+pub struct AppActionsService {
+    config: AppActionsConfig,
+    schema: Schema,
+    index: Index,
+    writer: Arc<Mutex<IndexWriter>>,
+    index_worker_handle: Option<JoinHandle<()>>,
+    watcher_handler: Option<JoinHandle<()>>,
+}
+
+impl AppActionsService {
+    /* fn load_existing_desktop_entries(
+        desktop_app_dir: &str,
+        index_reader: &IndexReader,
+        index_writer: &Arc<Mutex<IndexWriter>>,
+        schema: &Schema,
+    ) {
+        info!("Loading existing desktop entries");
+        let existing_desktop_entries = read_dir(&desktop_app_dir).unwrap();
+        for entry in existing_desktop_entries {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            let checksum = match generate_checksum(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("Failed to generate checksum for {}: {}", path.display(), e);
+                    continue;
+                }
+            };
+
+            let term = Term::from_field_text(
+                schema.get_field("path").unwrap(),
+                &path.to_string_lossy().to_string(),
+            );
+            // check if the entry is already in the index
+            let existing_entry = extract_doc_given_app_path(index_reader, &term).unwrap();
+            if let Some(existing_entry) = existing_entry {
+                debug!("Entry already exists for path: {}", path.display());
+                // verify checksum
+                let checksum_field = schema.get_field("checksum").unwrap();
+                let checksum_field_value = match existing_entry.get_first(checksum_field) {
+                    Some(v) => v,
+                    None => {
+                        warn!("Checksum field not found for entry: {}", path.display());
+                        continue;
+                    }
+                };
+                let checksum_field_value_str = match checksum_field_value.as_str() {
+                    Some(s) => s,
+                    None => {
+                        warn!(
+                            "Checksum field value is not a string for entry: {}",
+                            path.display()
+                        );
+                        continue;
+                    }
+                };
+                if checksum != checksum_field_value_str {
+                    // If checksums don't match, then delete the entry
+                    warn!("Checksum mismatch for entry: {}", path.display());
+                    if let Ok(writer) = index_writer.lock() {
+                        let term = Term::from_field_text(
+                            schema.get_field("path").unwrap(),
+                            &path.to_string_lossy().to_string(),
+                        );
+                        let doc =
+                            extract_doc_given_app_path(&index_reader, &term).unwrap_or_else(|e| {
+                                error!("Failed to extract doc: {}", e);
+                                None
+                            });
+                        if let Some(_doc) = doc {
+                            let _result = writer.delete_term(term);
+                            info!("Removed indexed app entry: {}", path.display());
+                        }
+                    }
+                } else {
+                    debug!("Checksum match for entry: {}", path.display());
+                    continue;
+                }
+            }
+            let desktop_entry = match parse_desktop_entry(&path) {
+                Some(d) => d,
+                None => {
+                    warn!("Failed to parse desktop entry: {}", path.display());
+                    continue;
+                }
+            };
+            debug!(
+                "Found desktop entry: {:?} {:?}",
+                desktop_entry.name, desktop_entry.comment
+            );
+
+            let doc = feed_doc(&schema, &desktop_entry, checksum, &path);
+            if let Ok(writer) = index_writer.lock() {
+                match writer.add_document(doc) {
+                    Ok(_) => (),
+                    Err(e) => error!("Failed to index app entry: {}", e),
+                }
+            }
+        }
+        if let Ok(mut writer) = index_writer.lock() {
+            if let Err(e) = writer.commit() {
+                error!("Failed to commit index: {:?}", e);
+            } else {
+                debug!("Committed indexed app data to disk.");
+            }
+        };
+        info!("Finished loading existing entries");
+    } */
+    /// Create the Tantivy schema for `.desktop` fields
+    fn create_schema() -> Schema {
+        let mut schema_builder = tantivy::schema::Schema::builder();
+        schema_builder.add_text_field("type", STRING | STORED);
+        schema_builder.add_text_field("name", STRING | STORED);
+        schema_builder.add_text_field("exec", STORED);
+        schema_builder.add_text_field("comment", TEXT);
+        schema_builder.add_text_field("generic_name", STRING | STORED);
+        schema_builder.add_text_field("categories", STRING | STORED);
+        schema_builder.add_text_field("keywords", TEXT | STORED);
+        schema_builder.add_text_field("icon", STORED);
+        schema_builder.add_text_field("checksum", STORED);
+        schema_builder.add_text_field("path", STRING);
+
+        schema_builder.build()
+    }
+
+    /// Create a new service instance.
+    pub fn new(config: &AppActionsConfig) -> anyhow::Result<Self> {
+        let home_dir =
+            dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Failed to get home directory"))?;
+        let schema = Self::create_schema();
+        let index_path = home_dir.join(&config.index_dir);
+
+        // Create the index if it doesn't exist
+        let index = if index_path.join("meta.json").exists() {
+            Index::open_in_dir(&index_path)?
+        } else {
+            Index::create_in_dir(&index_path, schema.clone())?
+        };
+
+        // TODO: We can configure this to be more fine-grained
+        let writer = Arc::new(Mutex::new(index.writer(50_000_000)?));
+        Ok(Self {
+            config: config.clone(),
+            schema,
+            index,
+            writer,
+            index_worker_handle: None,
+            watcher_handler: None,
+        })
+    }
+
+    pub async fn run(&mut self) -> anyhow::Result<()> {
+        info!("Starting App Action watcher...");
+        // Load existing entries, this should be in a separate task
+        let schema = self.schema.clone(); // make sure schema is Arc or Clone
+        let index_reader = self.index.reader()?; // Make sure this is thread safe
+        // Self::load_existing_desktop_entries(
+        //     &self.config.desktop_apps_dir,
+        //     &index_reader,
+        //     &self.writer.clone(),
+        //     &schema,
+        // );
+        let watch_path: PathBuf = self.config.schema_dir.clone().into();
+        if !watch_path.exists() {
+            anyhow::bail!("Watch path does not exist: {}", watch_path.display());
+        }
+
+        let (event_tx, mut event_rx) = mpsc::channel::<Event>(100);
+        let tx_clone = event_tx.clone();
+
+        // ========= Spawn async task that holds the watcher =========
+        let watch_path_clone = watch_path.clone();
+        self.watcher_handler = Some(tokio::spawn(async move {
+            let mut watcher = RecommendedWatcher::new(
+                move |res| {
+                    if let Ok(event) = res {
+                        let _ = tx_clone.blocking_send(event);
+                    } else if let Err(err) = res {
+                        error!("Watch error: {:?}", err);
+                    }
+                },
+                notify::Config::default(),
+            )
+            .expect("Failed to create watcher");
+
+            if let Err(e) = watcher.watch(&watch_path_clone, RecursiveMode::Recursive) {
+                error!("Failed to start watcher: {}", e);
+            } else {
+                info!("Watching path: {:?}", watch_path_clone);
+            }
+
+            // Keep the watcher alive in background (task won't exit unless manually dropped)
+            futures::future::pending::<()>().await;
+        }));
+
+        // ========= Event Debouncing & Indexing =========
+        let writer = Arc::clone(&self.writer);
+        let schema = self.schema.clone();
+        let reader = match self.index.reader() {
+            Ok(reader) => reader,
+            Err(err) => {
+                error!("Failed to get index reader: {}", err);
+                return Ok(());
+            }
+        };
+        self.index_worker_handle = Some(tokio::spawn(async move {
+            let debounce_duration = Duration::from_secs(2);
+            let mut pending = Vec::new();
+
+            loop {
+                tokio::select! {
+                    Some(event) = event_rx.recv() => {
+                        pending.push(event);
+                    }
+                    _ = time::sleep(debounce_duration), if !pending.is_empty() => {
+                        let mut unique_paths = HashMap::new();
+
+                        for event in pending.drain(..) {
+                            if let Some(path) = event.paths.get(0) {
+                                if path.extension().and_then(|s| s.to_str()) == Some("desktop") &&
+                                   (event.kind.is_create() || event.kind.is_modify()) || event.kind.is_remove() {
+                                    debug!("File created or modified: {}", path.display());
+                                    unique_paths.insert(path.clone(), event.kind.clone());
+                                }
+                            }
+                        }
+
+                        for (path, kind) in unique_paths {
+                            if kind.is_create() || kind.is_modify() {
+                                info!("New schema detected: {}", path.display());
+                            } else if kind.is_remove() {
+                                info!("Removing indexed app entry: {:?}", path.file_name());
+                            }
+                        }
+                        // if let Ok(mut writer) = writer.lock() {
+                        //     if let Err(e) = writer.commit() {
+                        //         error!("Failed to commit index: {:?}", e);
+                        //     } else {
+                        //         info!("Committed indexed app data to disk.");
+                        //     }
+                        // }
+                    }
+                }
+            }
+        }));
+        Ok(())
+    }
+
+    /// Search indexed applications using a free-form query.
+    pub fn search(&self, query_str: &str, limit: usize) -> tantivy::Result<Vec<AppInfo>> {
+        info!("Search Apps: {}", query_str);
+        let fields: Vec<Field> = self
+            .config
+            .searchable_fields
+            .iter()
+            .filter_map(|field_name| {
+                debug!("Get field: {}", field_name);
+                match self.schema.get_field(field_name) {
+                    Ok(field) => Some(field),
+                    Err(err) => {
+                        warn!("Failed to get field {}: {}", field_name, err);
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        let reader = self
+            .index
+            .reader_builder()
+            .reload_policy(tantivy::ReloadPolicy::OnCommitWithDelay)
+            .try_into()?;
+
+        let searcher = reader.searcher();
+        let query_parser = QueryParser::for_index(&self.index, fields);
+        let query = query_parser.parse_query(query_str)?;
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::new();
+
+        for (score, doc_addr) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_addr)?;
+
+            let mut app = AppInfo::default();
+            for (field, value) in doc.get_sorted_field_values() {
+                let field_name = self.schema.get_field_name(field).to_string();
+                // Join all values into a single string (semicolon-separated)
+                let joined_values = value
+                    .iter()
+                    .filter_map(|val| val.as_str())
+                    .collect::<Vec<_>>()
+                    .join(";");
+
+                set_app_field(&mut app, &field_name, joined_values);
+                app.score = score;
+            }
+
+            results.push(app);
+        }
+
+        Ok(results)
+    }
+    pub fn list_applications(&self, limit: usize) -> tantivy::Result<Vec<AppInfo>> {
+        info!("List applications: limit {}", limit);
+        let field_name = "type";
+        let search_term = "Application";
+        let field_to_lookup = match self.schema.get_field(field_name) {
+            Ok(field) => field,
+            Err(err) => {
+                error!("Failed to get field {}: {}", field_name, err);
+                return Err(err);
+            }
+        };
+
+        let reader = self
+            .index
+            .reader_builder()
+            .reload_policy(tantivy::ReloadPolicy::OnCommitWithDelay)
+            .try_into()?;
+
+        let searcher = reader.searcher();
+        let query_parser = QueryParser::for_index(&self.index, vec![field_to_lookup]);
+        let query = query_parser.parse_query(search_term)?;
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
+
+        let mut results = Vec::new();
+
+        for (_score, doc_addr) in top_docs {
+            let doc: TantivyDocument = searcher.doc(doc_addr)?;
+
+            let mut app = AppInfo::default();
+            for (field, value) in doc.get_sorted_field_values() {
+                let field_name = self.schema.get_field_name(field).to_string();
+                // Join all values into a single string (semicolon-separated)
+                let joined_values = value
+                    .iter()
+                    .filter_map(|val| val.as_str())
+                    .collect::<Vec<_>>()
+                    .join(";");
+
+                set_app_field(&mut app, &field_name, joined_values);
+            }
+
+            results.push(app);
+        }
+
+        Ok(results)
+    }
+
+    /// Graceful shutdown (optional: cancels task)
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
+        if let Some(handle) = &self.index_worker_handle {
+            debug!("Aborting indexer task");
+            handle.abort(); // Stop background debounce task
+        }
+
+        if let Some(handle) = &self.watcher_handler {
+            debug!("Aborting watcher task");
+            handle.abort(); // Stop background task
+        }
+        Ok(())
+    }
+}
+fn set_app_field(app: &mut AppInfo, field_name: &str, joined_values: String) {
+    match field_name {
+        "type" => app.type_ = joined_values,
+        "name" => app.name = joined_values,
+        "exec" => app.exec = joined_values,
+        "comment" => app.comment = joined_values,
+        "generic_name" => app.generic_name = joined_values,
+        "categories" => {
+            app.categories = joined_values.split(';').map(|s| s.to_string()).collect();
+        }
+        "keywords" => {
+            app.keywords = joined_values.split(';').map(|s| s.to_string()).collect();
+        }
+        "icon" => app.icon = joined_values,
+        "path" => app.path = joined_values,
+        _ => {}
+    }
+}
+
+/// Creates a `TantivyDocument` from a `DesktopEntry`, with the given checksum and path.
+///
+/// This function takes a `DesktopEntry` and creates a new `TantivyDocument` with the fields:
+///
+/// - `name`: the application name
+/// - `exec`: the application executable
+/// - `comment`: the application description
+/// - `generic_name`: the application generic name
+/// - `categories`: the application categories, joined with `;`
+/// - `keywords`: the application keywords, joined with `;`
+/// - `icon`: the application icon
+/// - `path`: the path to the `.desktop` file
+/// - `checksum`: the checksum of the `.desktop` file
+///
+/// If any of the fields are missing in the `DesktopEntry`, they will be filled with default values.
+///
+/// # Arguments
+///
+/// * `schema`: the `Schema` to use for creating the `TantivyDocument`
+/// * `desktop_entry`: the `DesktopEntry` to create the `TantivyDocument` from
+/// * `checksum`: the checksum of the `.desktop` file
+/// * `path`: the path to the `.desktop` file
+///
+/// # Returns
+///
+/// A `TantivyDocument` with the fields filled in from the `DesktopEntry`, checksum and path.
+// fn feed_doc(
+//     schema: &Schema,
+//     desktop_entry: &DesktopEntry,
+//     checksum: String,
+//     path: &Path,
+// ) -> TantivyDocument {
+//     doc!(
+//         schema.get_field("type").unwrap() => desktop_entry.type_,
+//         schema.get_field("name").unwrap() => desktop_entry.name,
+//         schema.get_field("exec").unwrap() => desktop_entry.exec.clone().unwrap_or_default(),
+//         schema.get_field("comment").unwrap() => desktop_entry.comment.clone().unwrap_or_default(),
+//         schema.get_field("generic_name").unwrap() => desktop_entry.generic_name.clone().unwrap_or_default(),
+//         schema.get_field("categories").unwrap() => desktop_entry.categories.join(";"),
+//         schema.get_field("keywords").unwrap() => desktop_entry.keywords.join(";"),
+//         schema.get_field("icon").unwrap() => desktop_entry.icon.clone().unwrap_or_default(),
+//         schema.get_field("path").unwrap() => path.to_string_lossy().to_string(),
+//         schema.get_field("checksum").unwrap() => checksum
+//     )
+// }
+
+/// Generates a SHA256 checksum for the file at the given path.
+///
+/// This function reads the contents of the specified file and computes its SHA256 hash,
+/// returning the resulting checksum as a hexadecimal string. If the file cannot be read,
+/// an I/O error is returned.
+///
+/// # Arguments
+///
+/// * `file_path` - A reference to the path of the file for which the checksum is to be generated.
+///
+/// # Returns
+///
+/// A `Result` containing the SHA256 checksum as a `String` if successful, or a `std::io::Error` if an error occurs during file reading.
+
+fn generate_checksum(file_path: &PathBuf) -> Result<String, std::io::Error> {
+    let file_bytes = match std::fs::read(&file_path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            error!("Failed to read file: {}", e);
+            return Err(e);
+        }
+    };
+
+    // Generate checksum
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&file_bytes);
+    let checksum = format!("{:x}", hasher.finalize());
+    Ok(checksum)
+}
+
+// A simple helper function to fetch a single document
+// given its id from our index.
+// It will be helpful to check our work.
+fn extract_doc_given_app_path(
+    reader: &IndexReader,
+    app_path: &Term,
+) -> tantivy::Result<Option<TantivyDocument>> {
+    let searcher = reader.searcher();
+
+    // This is the simplest query you can think of.
+    // It matches all of the documents containing a specific term.
+    //
+    // The second argument is here to tell we don't care about decoding positions,
+    // or term frequencies.
+    let term_query = TermQuery::new(app_path.clone(), IndexRecordOption::Basic);
+    let top_docs = searcher.search(&term_query, &TopDocs::with_limit(200))?;
+
+    if let Some((_score, doc_address)) = top_docs.first() {
+        let doc = searcher.doc(*doc_address)?;
+        Ok(Some(doc))
+    } else {
+        // no doc matching this ID.
+        Ok(None)
+    }
+}

--- a/mxsearch/app_actions/src/service.rs
+++ b/mxsearch/app_actions/src/service.rs
@@ -1,5 +1,8 @@
+use crate::utils::{parse_action_schema, ActionSchema, ActionSetting, Arg};
+use crate::{utils, AppActionsConfig};
 use log::{debug, error, info, warn};
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::Deserialize;
 use std::fs::read_dir;
 use std::{
     collections::HashMap,
@@ -7,15 +10,13 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-
-use crate::AppActionsConfig;
 use tantivy::query::TermQuery;
 use tantivy::schema::{Field, IndexRecordOption, Value, STRING};
 use tantivy::{
-    collector::TopDocs, doc, query::QueryParser, schema::{Schema, STORED, TEXT}, Document, Index,
-    IndexReader,
+    collector::TopDocs, doc, query::QueryParser, schema::{Schema, STORED, TEXT}, Document, Index, IndexReader,
     IndexWriter,
     TantivyDocument,
+    TantivyError,
     Term,
 };
 use tokio::{sync::mpsc, task::JoinHandle, time};
@@ -23,20 +24,24 @@ use zbus::zvariant::{DeserializeDict, SerializeDict, Type};
 
 #[derive(Type, SerializeDict, DeserializeDict, Debug, Default, Clone)]
 #[zvariant(signature = "dict")]
-pub struct AppInfo {
-    pub type_: String,
-    pub name: String,
-    pub generic_name: String,
-    pub keywords: Vec<String>,
-    pub comment: String,
-    pub icon: String,
-    pub categories: Vec<String>,
-    pub exec: String,
-    pub path: String,
-    pub score: f32,
+pub struct AppActions {
+    name: String,
+    icon: String,
+    exec: String,
+    section: String,
+    action: String,
+    description: String,
+    arg_key: String,
+    arg_value: String,
+    score: f32,
 }
-/// Public entry point for the app search service.
+pub enum FileIndexState {
+    IndexedAndUpToDate, // indexed & checksum matches
+    IndexedAndStale,    // indexed & checksum mismatch
+    NotIndexed,         // not in the index at all
+}
 
+/// Public entry point for the app actions service.
 #[derive()]
 pub struct AppActionsService {
     config: AppActionsConfig,
@@ -48,11 +53,61 @@ pub struct AppActionsService {
 }
 
 impl AppActionsService {
-    /* fn load_existing_desktop_entries(
+    fn get_index_state(
+        schema: &Schema,
+        new_checksum: &str,
+        file_path: &PathBuf,
+        index_reader: &IndexReader,
+        search_limit: usize,
+    ) -> Result<FileIndexState, TantivyError> {
+        // Check if last_modified is same then do not index
+        let field = match schema.get_field("path") {
+            Ok(field) => field,
+            Err(err) => {
+                error!("Failed to get the field: {}", err);
+                return Err(err);
+            }
+        };
+        let term = Term::from_field_text(field, &file_path.to_string_lossy().to_string());
+        // check if the entry is already in the index
+        let existing_entry = extract_doc(index_reader, &term, search_limit)?;
+        if let Some(existing_entry) = existing_entry {
+            // verify checksum
+            let old_checksum_field = schema.get_field("checksum")?;
+            let old_checksum_value = match existing_entry.get_first(old_checksum_field) {
+                Some(v) => v,
+                None => {
+                    warn!(
+                        "The checksum field isn't found for entry: {}",
+                        file_path.display()
+                    );
+                    return Ok(FileIndexState::NotIndexed);
+                }
+            };
+            if let Some(last_modified_field_value) = old_checksum_value.as_str() {
+                return if last_modified_field_value == new_checksum {
+                    debug!(
+                        "Entry already exists, and last_modified is the same for path: {}",
+                        file_path.display()
+                    );
+                    Ok(FileIndexState::IndexedAndUpToDate)
+                } else {
+                    debug!(
+                        "Entry already exists, but last_modified is different for a path: {}",
+                        file_path.display()
+                    );
+                    Ok(FileIndexState::IndexedAndStale)
+                };
+            }
+        }
+        Ok(FileIndexState::NotIndexed)
+    }
+    fn load_existing_desktop_entries(
         desktop_app_dir: &str,
         index_reader: &IndexReader,
         index_writer: &Arc<Mutex<IndexWriter>>,
         schema: &Schema,
+        search_limit: usize,
     ) {
         info!("Loading existing desktop entries");
         let existing_desktop_entries = read_dir(&desktop_app_dir).unwrap();
@@ -72,7 +127,11 @@ impl AppActionsService {
                 &path.to_string_lossy().to_string(),
             );
             // check if the entry is already in the index
-            let existing_entry = extract_doc_given_app_path(index_reader, &term).unwrap();
+            let existing_entry =
+                extract_doc(index_reader, &term, search_limit).unwrap_or_else(|e| {
+                    error!("Failed to extract doc: {}", e);
+                    None
+                });
             if let Some(existing_entry) = existing_entry {
                 debug!("Entry already exists for path: {}", path.display());
                 // verify checksum
@@ -98,42 +157,30 @@ impl AppActionsService {
                     // If checksums don't match, then delete the entry
                     warn!("Checksum mismatch for entry: {}", path.display());
                     if let Ok(writer) = index_writer.lock() {
-                        let term = Term::from_field_text(
-                            schema.get_field("path").unwrap(),
-                            &path.to_string_lossy().to_string(),
-                        );
-                        let doc =
-                            extract_doc_given_app_path(&index_reader, &term).unwrap_or_else(|e| {
-                                error!("Failed to extract doc: {}", e);
-                                None
-                            });
-                        if let Some(_doc) = doc {
-                            let _result = writer.delete_term(term);
-                            info!("Removed indexed app entry: {}", path.display());
-                        }
+                        let _result = writer.delete_term(term);
+                        info!("Removed indexed action entry: {}", path.display());
                     }
                 } else {
                     debug!("Checksum match for entry: {}", path.display());
                     continue;
                 }
             }
-            let desktop_entry = match parse_desktop_entry(&path) {
+            let action_schema = match parse_action_schema(&path) {
                 Some(d) => d,
                 None => {
-                    warn!("Failed to parse desktop entry: {}", path.display());
+                    warn!("Failed to parse action schema: {}", path.display());
                     continue;
                 }
             };
-            debug!(
-                "Found desktop entry: {:?} {:?}",
-                desktop_entry.name, desktop_entry.comment
-            );
+            debug!("Found action schema: {:?}", action_schema.name);
 
-            let doc = feed_doc(&schema, &desktop_entry, checksum, &path);
+            let docs = feed_docs(&schema, &action_schema, checksum, &path);
             if let Ok(writer) = index_writer.lock() {
-                match writer.add_document(doc) {
-                    Ok(_) => (),
-                    Err(e) => error!("Failed to index app entry: {}", e),
+                for doc in docs {
+                    match writer.add_document(doc) {
+                        Ok(_) => info!("Indexed existing action schema: {}", action_schema.name),
+                        Err(e) => error!("Failed to index the existing action schema: {}", e),
+                    }
                 }
             }
         }
@@ -145,20 +192,23 @@ impl AppActionsService {
             }
         };
         info!("Finished loading existing entries");
-    } */
+    }
     /// Create the Tantivy schema for `.desktop` fields
     fn create_schema() -> Schema {
         let mut schema_builder = tantivy::schema::Schema::builder();
-        schema_builder.add_text_field("type", STRING | STORED);
+        // top-level fields
         schema_builder.add_text_field("name", STRING | STORED);
-        schema_builder.add_text_field("exec", STORED);
-        schema_builder.add_text_field("comment", TEXT);
-        schema_builder.add_text_field("generic_name", STRING | STORED);
-        schema_builder.add_text_field("categories", STRING | STORED);
-        schema_builder.add_text_field("keywords", TEXT | STORED);
-        schema_builder.add_text_field("icon", STORED);
+        schema_builder.add_text_field("icon", STRING | STORED);
+        schema_builder.add_text_field("exec", STRING | STORED);
         schema_builder.add_text_field("checksum", STORED);
-        schema_builder.add_text_field("path", STRING);
+        schema_builder.add_text_field("path", STRING | STORED);
+
+        // section fields (each config block)
+        schema_builder.add_text_field("section", STRING | STORED); // e.g. EnableWifi, EnableBluetooth
+        schema_builder.add_text_field("action", TEXT | STORED); // searchable action text
+        schema_builder.add_text_field("description", TEXT | STORED); // searchable description
+        schema_builder.add_text_field("arg_key", STRING | STORED); // e.g. "path"
+        schema_builder.add_text_field("arg_value", STRING | STORED); // e.g. "network", "bluetooth"
 
         schema_builder.build()
     }
@@ -189,17 +239,33 @@ impl AppActionsService {
         })
     }
 
+    /// Starts the App Actions service.
+    ///
+    /// This function starts a separate task which watches the `schema_dir` for new or modified
+    /// TOML files. When a change is detected, it will parse the TOML file, generate a checksum,
+    /// and index the file in the Tantivy index. The index will be committed to disk after every
+    /// change.
+    ///
+    /// The service will also load existing entries from the index on startup.
+    ///
+    /// If the watch path does not exist, this function will return an error.
+    ///
+    /// This function is marked as `async` because it uses async I/O to read the watch path and
+    /// index the files. However, it does not use `await` because it uses a separate task to do
+    /// the work.
     pub async fn run(&mut self) -> anyhow::Result<()> {
         info!("Starting App Action watcher...");
         // Load existing entries, this should be in a separate task
         let schema = self.schema.clone(); // make sure schema is Arc or Clone
         let index_reader = self.index.reader()?; // Make sure this is thread safe
-        // Self::load_existing_desktop_entries(
-        //     &self.config.desktop_apps_dir,
-        //     &index_reader,
-        //     &self.writer.clone(),
-        //     &schema,
-        // );
+        let search_limit = self.config.search_limit;
+        Self::load_existing_desktop_entries(
+            &self.config.schema_dir,
+            &index_reader,
+            &self.writer.clone(),
+            &schema,
+            search_limit,
+        );
         let watch_path: PathBuf = self.config.schema_dir.clone().into();
         if !watch_path.exists() {
             anyhow::bail!("Watch path does not exist: {}", watch_path.display());
@@ -243,6 +309,7 @@ impl AppActionsService {
                 return Ok(());
             }
         };
+
         self.index_worker_handle = Some(tokio::spawn(async move {
             let debounce_duration = Duration::from_secs(2);
             let mut pending = Vec::new();
@@ -257,28 +324,142 @@ impl AppActionsService {
 
                         for event in pending.drain(..) {
                             if let Some(path) = event.paths.get(0) {
-                                if path.extension().and_then(|s| s.to_str()) == Some("desktop") &&
+                                if path.extension().and_then(|s| s.to_str()) == Some("toml") &&
+                                !path.starts_with(".") &&
                                    (event.kind.is_create() || event.kind.is_modify()) || event.kind.is_remove() {
-                                    debug!("File created or modified: {}", path.display());
                                     unique_paths.insert(path.clone(), event.kind.clone());
                                 }
                             }
                         }
 
                         for (path, kind) in unique_paths {
-                            if kind.is_create() || kind.is_modify() {
-                                info!("New schema detected: {}", path.display());
-                            } else if kind.is_remove() {
-                                info!("Removing indexed app entry: {:?}", path.file_name());
+                               match kind {
+                                EventKind::Any => {}
+                                EventKind::Access(_) => {}
+                                EventKind::Create(_) => {
+                                  debug!("New schema detected: {}", path.display());
+                                  if let Some(action_schema) = utils::parse_action_schema(&path) {
+                                    debug!("action_schema: {:?}", action_schema);
+                                    let checksum = match generate_checksum(&path) {
+                                        Ok(c) => c,
+                                        Err(e) => {
+                                            warn!("Failed to generate checksum for {}: {}", path.display(), e);
+                                            String::new()
+                                        }
+                                    };
+                                    let docs = feed_docs(&schema, &action_schema, checksum, &path);
+                                    if let Ok(writer) = writer.lock() {
+                                            for doc in docs {
+                                                match writer.add_document(doc) {
+                                                Ok(_) => info!("Indexed action entry: {}", action_schema.name),
+                                                Err(e) => error!("Failed to index action entry: {}", e),
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                EventKind::Modify(_) => {
+                                    debug!("Schema modification detected: {}", path.display());
+                                    if let Some(action_schema) = utils::parse_action_schema(&path) {
+                                        let checksum = match generate_checksum(&path) {
+                                        Ok(c) => c,
+                                        Err(e) => {
+                                            warn!("Failed to generate checksum for {}: {}", path.display(), e);
+                                            String::new()
+                                            }
+                                        };
+                                        let state = match Self::get_index_state(&schema, &checksum, &path, &reader, search_limit) {
+                                            Ok(state) => state,
+                                            Err(e) => {
+                                                error!("Failed to get index state for {}: {}", path.display(), e);
+                                                continue;
+                                            }
+                                        };
+                                        match state {
+                                            FileIndexState::IndexedAndUpToDate => {
+                                                debug!(
+                                                    "Entry already exists, and checksum is the same for schema: {}",
+                                                    action_schema.name
+                                                );
+                                                continue;
+                                            }
+                                            FileIndexState::IndexedAndStale => {
+                                                if let Ok(writer) = writer.lock() {
+                                                    let field = match schema.get_field("path") {
+                                                        Ok(field) => field,
+                                                        Err(err) => {
+                                                            error!("Failed to get field - path: {}", err);
+                                                            continue;
+                                                        }
+                                                    };
+                                                    //TODO: we can delete this in get_index_state or return from that function
+                                                    let term = Term::from_field_text(
+                                                        field,
+                                                        &path.to_string_lossy().to_string(),
+                                                    );
+                                                    let doc =
+                                                        extract_doc(&index_reader, &term, search_limit).unwrap_or_else(|e| {
+                                                            error!("Failed to extract doc: {}", e);
+                                                            None
+                                                        });
+                                                    if let Some(_doc) = doc {
+                                                        let _result = writer.delete_term(term);
+                                                        info!("Removed indexed file entry: {:?}", path.file_name());
+                                                    }
+                                                    let docs = feed_docs(&schema, &action_schema, checksum, &path);
+                                                    for doc in docs {
+                                                        match writer.add_document(doc) {
+                                                            Ok(_) => info!("Indexed new action schema: {}", action_schema.name),
+                                                            Err(e) => error!("Failed to index the new action schema: {}", e),
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            FileIndexState::NotIndexed => {
+                                                 let docs = feed_docs(&schema, &action_schema, checksum, &path);
+                                                if let Ok(writer) = writer.lock() {
+                                                    for doc in docs {
+                                                        match writer.add_document(doc) {
+                                                            Ok(_) => info!("Indexed new action schema: {}", action_schema.name),
+                                                            Err(e) => error!("Failed to index new action schema: {}", e),
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                EventKind::Remove(_) => {
+                                    debug!("Removing indexed action entry: {:?}", path.file_name());
+                                    if let Ok(writer) = writer.lock() {
+                                        let field = match schema.get_field("path") {
+                                            Ok(field) => field,
+                                            Err(err) => {
+                                                error!("Failed to get field - path: {}", err);
+                                                continue;
+                                            }
+                                        };
+                                        let term = Term::from_field_text(field, &path.to_string_lossy().to_string());
+                                       let doc= extract_doc(&reader, &term, search_limit).unwrap_or_else(|e| {
+                                                error!("Failed to extract doc: {}", e);
+                                                None
+                                            });
+                                        if let Some(_doc) = doc {
+                                            let _result =writer.delete_term(term);
+                                            info!("Removed indexed action entry: {:?}", path.file_name());
+                                        }
+                                    }
+                                }
+                                EventKind::Other => {}
                             }
                         }
-                        // if let Ok(mut writer) = writer.lock() {
-                        //     if let Err(e) = writer.commit() {
-                        //         error!("Failed to commit index: {:?}", e);
-                        //     } else {
-                        //         info!("Committed indexed app data to disk.");
-                        //     }
-                        // }
+                        if let Ok(mut writer) = writer.lock() {
+                            if let Err(e) = writer.commit() {
+                                error!("Failed to commit index: {:?}", e);
+                            } else {
+                                info!("Committed indexed app data to disk.");
+                            }
+                        }
                     }
                 }
             }
@@ -286,9 +467,8 @@ impl AppActionsService {
         Ok(())
     }
 
-    /// Search indexed applications using a free-form query.
-    pub fn search(&self, query_str: &str, limit: usize) -> tantivy::Result<Vec<AppInfo>> {
-        info!("Search Apps: {}", query_str);
+    /// Search indexed action using a free-form query.
+    pub fn search(&self, query_str: &str, limit: usize) -> tantivy::Result<Vec<AppActions>> {
         let fields: Vec<Field> = self
             .config
             .searchable_fields
@@ -305,6 +485,7 @@ impl AppActionsService {
             })
             .collect();
 
+        // Define reload policy to reload the index on commit
         let reader = self
             .index
             .reader_builder()
@@ -322,7 +503,7 @@ impl AppActionsService {
         for (score, doc_addr) in top_docs {
             let doc: TantivyDocument = searcher.doc(doc_addr)?;
 
-            let mut app = AppInfo::default();
+            let mut app_action = AppActions::default();
             for (field, value) in doc.get_sorted_field_values() {
                 let field_name = self.schema.get_field_name(field).to_string();
                 // Join all values into a single string (semicolon-separated)
@@ -332,58 +513,11 @@ impl AppActionsService {
                     .collect::<Vec<_>>()
                     .join(";");
 
-                set_app_field(&mut app, &field_name, joined_values);
-                app.score = score;
+                set_app_field(&mut app_action, &field_name, joined_values);
+                app_action.score = score;
             }
 
-            results.push(app);
-        }
-
-        Ok(results)
-    }
-    pub fn list_applications(&self, limit: usize) -> tantivy::Result<Vec<AppInfo>> {
-        info!("List applications: limit {}", limit);
-        let field_name = "type";
-        let search_term = "Application";
-        let field_to_lookup = match self.schema.get_field(field_name) {
-            Ok(field) => field,
-            Err(err) => {
-                error!("Failed to get field {}: {}", field_name, err);
-                return Err(err);
-            }
-        };
-
-        let reader = self
-            .index
-            .reader_builder()
-            .reload_policy(tantivy::ReloadPolicy::OnCommitWithDelay)
-            .try_into()?;
-
-        let searcher = reader.searcher();
-        let query_parser = QueryParser::for_index(&self.index, vec![field_to_lookup]);
-        let query = query_parser.parse_query(search_term)?;
-
-        let top_docs = searcher.search(&query, &TopDocs::with_limit(limit))?;
-
-        let mut results = Vec::new();
-
-        for (_score, doc_addr) in top_docs {
-            let doc: TantivyDocument = searcher.doc(doc_addr)?;
-
-            let mut app = AppInfo::default();
-            for (field, value) in doc.get_sorted_field_values() {
-                let field_name = self.schema.get_field_name(field).to_string();
-                // Join all values into a single string (semicolon-separated)
-                let joined_values = value
-                    .iter()
-                    .filter_map(|val| val.as_str())
-                    .collect::<Vec<_>>()
-                    .join(";");
-
-                set_app_field(&mut app, &field_name, joined_values);
-            }
-
-            results.push(app);
+            results.push(app_action);
         }
 
         Ok(results)
@@ -403,70 +537,79 @@ impl AppActionsService {
         Ok(())
     }
 }
-fn set_app_field(app: &mut AppInfo, field_name: &str, joined_values: String) {
+
+/// Set a field on an `AppActions` struct based on the given `field_name` and
+/// `joined_values`.
+///
+/// If the `field_name` does not match any of the fields on `AppActions`, this
+/// function does nothing.
+///
+/// # Arguments
+///
+/// * `app`: the `AppActions` to modify
+/// * `field_name`: the name of the field to set
+/// * `joined_values`: the value to set the field to, which should be a single
+///   string which is the result of joining multiple values together with a
+///   semicolon separator.
+fn set_app_field(app: &mut AppActions, field_name: &str, joined_values: String) {
     match field_name {
-        "type" => app.type_ = joined_values,
         "name" => app.name = joined_values,
-        "exec" => app.exec = joined_values,
-        "comment" => app.comment = joined_values,
-        "generic_name" => app.generic_name = joined_values,
-        "categories" => {
-            app.categories = joined_values.split(';').map(|s| s.to_string()).collect();
-        }
-        "keywords" => {
-            app.keywords = joined_values.split(';').map(|s| s.to_string()).collect();
-        }
         "icon" => app.icon = joined_values,
-        "path" => app.path = joined_values,
+        "exec" => app.exec = joined_values,
+        "section" => app.section = joined_values,
+        "action" => app.action = joined_values,
+        "description" => app.description = joined_values,
+        "arg_key" => app.arg_key = joined_values,
+        "arg_value" => app.arg_value = joined_values,
         _ => {}
     }
 }
 
-/// Creates a `TantivyDocument` from a `DesktopEntry`, with the given checksum and path.
-///
-/// This function takes a `DesktopEntry` and creates a new `TantivyDocument` with the fields:
-///
-/// - `name`: the application name
-/// - `exec`: the application executable
-/// - `comment`: the application description
-/// - `generic_name`: the application generic name
-/// - `categories`: the application categories, joined with `;`
-/// - `keywords`: the application keywords, joined with `;`
-/// - `icon`: the application icon
-/// - `path`: the path to the `.desktop` file
-/// - `checksum`: the checksum of the `.desktop` file
-///
-/// If any of the fields are missing in the `DesktopEntry`, they will be filled with default values.
-///
-/// # Arguments
-///
-/// * `schema`: the `Schema` to use for creating the `TantivyDocument`
-/// * `desktop_entry`: the `DesktopEntry` to create the `TantivyDocument` from
-/// * `checksum`: the checksum of the `.desktop` file
-/// * `path`: the path to the `.desktop` file
-///
-/// # Returns
-///
-/// A `TantivyDocument` with the fields filled in from the `DesktopEntry`, checksum and path.
-// fn feed_doc(
-//     schema: &Schema,
-//     desktop_entry: &DesktopEntry,
-//     checksum: String,
-//     path: &Path,
-// ) -> TantivyDocument {
-//     doc!(
-//         schema.get_field("type").unwrap() => desktop_entry.type_,
-//         schema.get_field("name").unwrap() => desktop_entry.name,
-//         schema.get_field("exec").unwrap() => desktop_entry.exec.clone().unwrap_or_default(),
-//         schema.get_field("comment").unwrap() => desktop_entry.comment.clone().unwrap_or_default(),
-//         schema.get_field("generic_name").unwrap() => desktop_entry.generic_name.clone().unwrap_or_default(),
-//         schema.get_field("categories").unwrap() => desktop_entry.categories.join(";"),
-//         schema.get_field("keywords").unwrap() => desktop_entry.keywords.join(";"),
-//         schema.get_field("icon").unwrap() => desktop_entry.icon.clone().unwrap_or_default(),
-//         schema.get_field("path").unwrap() => path.to_string_lossy().to_string(),
-//         schema.get_field("checksum").unwrap() => checksum
-//     )
-// }
+/// Create a `Vec` of `TantivyDocument`s from a `&ActionSchema`, with the given checksum and path.
+pub fn feed_docs(
+    schema: &Schema,
+    action_schema: &ActionSchema,
+    checksum: String,
+    path: &Path,
+) -> Vec<TantivyDocument> {
+    let mut docs = Vec::new();
+
+    // Get tantivy fields once for efficiency:
+    let name_field = schema.get_field("name").unwrap();
+    let icon_field = schema.get_field("icon").unwrap();
+    let exec_field = schema.get_field("exec").unwrap();
+    let section_field = schema.get_field("section").unwrap();
+    let action_field = schema.get_field("action").unwrap();
+    let description_field = schema.get_field("description").unwrap();
+    let arg_key_field = schema.get_field("arg_key").unwrap();
+    let arg_value_field = schema.get_field("arg_value").unwrap();
+    let path_field = schema.get_field("path").unwrap();
+    let checksum_field = schema.get_field("checksum").unwrap();
+
+    for (section_name, action_setting) in &action_schema.actions {
+        // Create document per action section
+        let mut doc = TantivyDocument::default();
+
+        // top-level fields
+        doc.add_text(name_field, &action_schema.name);
+        doc.add_text(icon_field, &action_schema.icon);
+        doc.add_text(exec_field, &action_schema.exec);
+
+        // section-level fields
+        doc.add_text(section_field, section_name); // e.g. "EnableWifi"
+        doc.add_text(action_field, &action_setting.action); // e.g. "Enable WiFi"
+        doc.add_text(description_field, &action_setting.description); // e.g. "Enable wireless network"
+
+        doc.add_text(arg_key_field, "path"); // because your Arg has only `path` key
+        doc.add_text(arg_value_field, &action_setting.arg.path); // e.g. "network"
+
+        doc.add_text(path_field, &path.to_string_lossy());
+        doc.add_text(checksum_field, &checksum);
+
+        docs.push(doc);
+    }
+    docs
+}
 
 /// Generates a SHA256 checksum for the file at the given path.
 ///
@@ -501,9 +644,10 @@ fn generate_checksum(file_path: &PathBuf) -> Result<String, std::io::Error> {
 // A simple helper function to fetch a single document
 // given its id from our index.
 // It will be helpful to check our work.
-fn extract_doc_given_app_path(
+fn extract_doc(
     reader: &IndexReader,
     app_path: &Term,
+    search_limit: usize,
 ) -> tantivy::Result<Option<TantivyDocument>> {
     let searcher = reader.searcher();
 
@@ -513,7 +657,7 @@ fn extract_doc_given_app_path(
     // The second argument is here to tell we don't care about decoding positions,
     // or term frequencies.
     let term_query = TermQuery::new(app_path.clone(), IndexRecordOption::Basic);
-    let top_docs = searcher.search(&term_query, &TopDocs::with_limit(200))?;
+    let top_docs = searcher.search(&term_query, &TopDocs::with_limit(search_limit))?;
 
     if let Some((_score, doc_address)) = top_docs.first() {
         let doc = searcher.doc(*doc_address)?;

--- a/mxsearch/app_actions/src/service.rs
+++ b/mxsearch/app_actions/src/service.rs
@@ -1,5 +1,5 @@
-use crate::utils::{parse_action_schema, ActionSchema, ActionSetting, Arg};
-use crate::{utils, AppActionsConfig};
+use crate::utils::{ActionSchema, ActionSetting, Arg, parse_action_schema};
+use crate::{AppActionsConfig, utils};
 use log::{debug, error, info, warn};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
@@ -11,13 +11,13 @@ use std::{
     time::Duration,
 };
 use tantivy::query::TermQuery;
-use tantivy::schema::{Field, IndexRecordOption, Value, STRING};
+use tantivy::schema::{Field, IndexRecordOption, STRING, Value};
 use tantivy::{
-    collector::TopDocs, doc, query::QueryParser, schema::{Schema, STORED, TEXT}, Document, Index, IndexReader,
-    IndexWriter,
-    TantivyDocument,
-    TantivyError,
-    Term,
+    Document, Index, IndexReader, IndexWriter, TantivyDocument, TantivyError, Term,
+    collector::TopDocs,
+    doc,
+    query::QueryParser,
+    schema::{STORED, Schema, TEXT},
 };
 use tokio::{sync::mpsc, task::JoinHandle, time};
 use zbus::zvariant::{DeserializeDict, SerializeDict, Type};
@@ -513,7 +513,7 @@ impl AppActionsService {
                     .collect::<Vec<_>>()
                     .join(";");
 
-                set_app_field(&mut app_action, &field_name, joined_values);
+                set_app_action_field(&mut app_action, &field_name, joined_values, &query_str);
                 app_action.score = score;
             }
 
@@ -538,20 +538,25 @@ impl AppActionsService {
     }
 }
 
-/// Set a field on an `AppActions` struct based on the given `field_name` and
-/// `joined_values`.
+/// Populate fields of `AppActions` from a given `joined_values` string
+/// (semicolon-separated) based on a `field_name`.
 ///
-/// If the `field_name` does not match any of the fields on `AppActions`, this
-/// function does nothing.
+/// If `field_name` is "arg_value" and the value is "%KEYWORD%", the
+/// `search_query` is used instead.
 ///
-/// # Arguments
+/// # Parameters
 ///
-/// * `app`: the `AppActions` to modify
-/// * `field_name`: the name of the field to set
-/// * `joined_values`: the value to set the field to, which should be a single
-///   string which is the result of joining multiple values together with a
-///   semicolon separator.
-fn set_app_field(app: &mut AppActions, field_name: &str, joined_values: String) {
+/// * `app`: The `AppActions` instance to populate.
+/// * `field_name`: The name of the field to populate.
+/// * `joined_values`: The value to assign to the field.
+/// * `search_query`: The search string to use if the `field_name` is
+///   "arg_value" and the value is "%KEYWORD%".
+fn set_app_action_field(
+    app: &mut AppActions,
+    field_name: &str,
+    joined_values: String,
+    search_query: &str,
+) {
     match field_name {
         "name" => app.name = joined_values,
         "icon" => app.icon = joined_values,
@@ -560,7 +565,13 @@ fn set_app_field(app: &mut AppActions, field_name: &str, joined_values: String) 
         "action" => app.action = joined_values,
         "description" => app.description = joined_values,
         "arg_key" => app.arg_key = joined_values,
-        "arg_value" => app.arg_value = joined_values,
+        "arg_value" => {
+            if joined_values.to_lowercase() == "%keyword%" {
+                app.arg_value = search_query.to_string();
+            } else {
+                app.arg_value = joined_values;
+            }
+        }
         _ => {}
     }
 }

--- a/mxsearch/app_actions/src/service.rs
+++ b/mxsearch/app_actions/src/service.rs
@@ -1,5 +1,5 @@
-use crate::utils::{ActionSchema, ActionSetting, Arg, parse_action_schema};
-use crate::{AppActionsConfig, utils};
+use crate::utils::{parse_action_schema, ActionSchema, ActionSetting, Arg};
+use crate::{utils, AppActionsConfig};
 use log::{debug, error, info, warn};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
@@ -11,13 +11,13 @@ use std::{
     time::Duration,
 };
 use tantivy::query::TermQuery;
-use tantivy::schema::{Field, IndexRecordOption, STRING, Value};
+use tantivy::schema::{Field, IndexRecordOption, Value, STRING};
 use tantivy::{
-    Document, Index, IndexReader, IndexWriter, TantivyDocument, TantivyError, Term,
-    collector::TopDocs,
-    doc,
-    query::QueryParser,
-    schema::{STORED, Schema, TEXT},
+    collector::TopDocs, doc, query::QueryParser, schema::{Schema, STORED, TEXT}, Document, Index, IndexReader,
+    IndexWriter,
+    TantivyDocument,
+    TantivyError,
+    Term,
 };
 use tokio::{sync::mpsc, task::JoinHandle, time};
 use zbus::zvariant::{DeserializeDict, SerializeDict, Type};
@@ -25,15 +25,15 @@ use zbus::zvariant::{DeserializeDict, SerializeDict, Type};
 #[derive(Type, SerializeDict, DeserializeDict, Debug, Default, Clone)]
 #[zvariant(signature = "dict")]
 pub struct AppActions {
-    name: String,
-    icon: String,
-    exec: String,
-    section: String,
-    action: String,
-    description: String,
-    arg_key: String,
-    arg_value: String,
-    score: f32,
+    pub name: String,
+    pub icon: String,
+    pub exec: String,
+    pub section: String,
+    pub action: String,
+    pub description: String,
+    pub arg_key: String,
+    pub arg_value: String,
+    pub score: f32,
 }
 pub enum FileIndexState {
     IndexedAndUpToDate, // indexed & checksum matches

--- a/mxsearch/app_actions/src/utils.rs
+++ b/mxsearch/app_actions/src/utils.rs
@@ -1,0 +1,48 @@
+use log::error;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+pub struct ActionSchema {
+    pub name: String,
+    pub icon: String,
+    pub exec: String,
+
+    #[serde(flatten)]
+    pub actions: HashMap<String, ActionSetting>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ActionSetting {
+    pub action: String,
+    pub description: String,
+    pub arg: Arg,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Arg {
+    pub path: String,
+}
+
+pub fn parse_action_schema(schema_path: &PathBuf) -> Option<ActionSchema> {
+    // Read file contents
+    let toml_str = match fs::read_to_string(schema_path) {
+        Ok(res) => res,
+        Err(err) => {
+            error!("Failed to read a schema file: {}", err);
+            return None;
+        }
+    };
+
+    // Parse to struct
+    let schema: ActionSchema = match toml::from_str(&toml_str) {
+        Ok(res) => res,
+        Err(err) => {
+            error!("Failed to parse a schema file: {}", err);
+            return None;
+        }
+    };
+    Some(schema)
+}

--- a/mxsearch/settings.toml.example
+++ b/mxsearch/settings.toml.example
@@ -27,5 +27,14 @@ searchable_fields = [
     "content"
 ]
 allowed_extensions = ["txt", "yaml", "rtf", "xml", "toml"]
-
+[app_actions]
+enable_search = true
+index_dir = ".config/mxsearch/index/app_actions"
+schema_dir = "/usr/share/mxsearch/actions"
+search_limit = 15
+searchable_fields = [
+    "action",
+    "name",
+    "description"
+]
 

--- a/mxsearch/src/error.rs
+++ b/mxsearch/src/error.rs
@@ -10,6 +10,8 @@ pub enum ServerError {
     FailedStartAppSearchService(anyhow::Error),
     #[error("Failed to start file search service: {0}")]
     FailedStartFileSearchService(anyhow::Error),
+    #[error("Failed to start app actions service: {0}")]
+    FailedStartAppActionsService(anyhow::Error),
     #[error("Failed to start dbus server: {0}")]
     FailedStartDBusServer(zbus::Error),
 }

--- a/mxsearch/src/lib.rs
+++ b/mxsearch/src/lib.rs
@@ -2,3 +2,4 @@ pub mod error;
 pub mod service;
 pub use apps::AppInfo;
 pub use files::FileInfo;
+pub use app_actions::AppActions;

--- a/mxsearch/src/main.rs
+++ b/mxsearch/src/main.rs
@@ -5,6 +5,7 @@ mod service;
 use crate::error::ServerError;
 use crate::server::{ServerInterface, SERVED_AT};
 use anyhow::{Context, Result};
+use app_actions::{AppActionsConfig, AppActionsService};
 use apps::{AppSearchService, Apps as AppSearchConfig};
 use files::{FileSearchService, FilesConfig as FileSearchConfig};
 use log::{debug, error, info};
@@ -23,6 +24,7 @@ pub struct SearchConfig {
     pub general: General,
     pub apps: AppSearchConfig,
     pub files: FileSearchConfig,
+    pub app_actions: AppActionsConfig,
 }
 fn load_config<P: AsRef<Path>>(path: P) -> Result<SearchConfig> {
     let content = fs::read_to_string(path)?;
@@ -74,6 +76,14 @@ async fn main() -> Result<(), ServerError> {
         }
     };
 
+    let mut app_action_service = match AppActionsService::new(&config.app_actions) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Failed to create app actions service: {}", e);
+            return Err(ServerError::FailedStartAppActionsService(e));
+        }
+    };
+
     if config.apps.enable_search_apps {
         match app_search_service.run().await {
             Ok(()) => debug!("AppSearchService started"),
@@ -93,13 +103,25 @@ async fn main() -> Result<(), ServerError> {
             }
         }
     }
+
+    if config.app_actions.enable_search {
+        match app_action_service.run().await {
+            Ok(()) => debug!("FileSearchService started"),
+            Err(e) => {
+                error!("Failed to start FileSearchService: {}", e);
+                return Err(ServerError::FailedStartAppActionsService(e));
+            }
+        }
+    }
     let arc_app_search_service = Arc::new(app_search_service);
     let arc_file_search_service = Arc::new(file_search_service);
+    let arc_app_actions_service = Arc::new(app_action_service);
     // Build and register the D-Bus server (blocking until shutdown)
     let config_server = ServerInterface {
         config: config.clone(),
         app_search_service: arc_app_search_service.clone(),
         file_search_service: arc_file_search_service.clone(),
+        app_actions_service: arc_app_actions_service.clone(),
     };
 
     debug!("D-Bus server registered at {}", SERVED_AT);
@@ -113,6 +135,14 @@ async fn main() -> Result<(), ServerError> {
         Ok(()) => {
             info!("Received SIGINT, shutting down");
             match arc_app_search_service.shutdown().await {
+                Ok(()) => info!("Shutdown successful"),
+                Err(e) => error!("Failed to shutdown: {}", e),
+            }
+            match arc_file_search_service.shutdown().await {
+                Ok(()) => info!("Shutdown successful"),
+                Err(e) => error!("Failed to shutdown: {}", e),
+            }
+            match arc_app_actions_service.shutdown().await {
                 Ok(()) => info!("Shutdown successful"),
                 Err(e) => error!("Failed to shutdown: {}", e),
             }

--- a/mxsearch/src/server.rs
+++ b/mxsearch/src/server.rs
@@ -22,6 +22,7 @@ pub struct ServerInterface {
     pub(crate) config: SearchConfig,
     pub app_search_service: Arc<AppSearchService>,
     pub file_search_service: Arc<files::FileSearchService>,
+    pub app_actions_service: Arc<app_actions::AppActionsService>,
 }
 
 #[dbus_interface(name = "org.mechanix.MxSearch")]

--- a/mxsearch/src/server.rs
+++ b/mxsearch/src/server.rs
@@ -1,5 +1,6 @@
 use crate::SearchConfig;
 use anyhow::Result;
+use app_actions::service::AppActions;
 use apps::{AppInfo, AppSearchService};
 use files::FileInfo;
 use log::{debug, error, info, warn};
@@ -96,6 +97,20 @@ impl ServerInterface {
         debug!("result: {:?}", results);
         Ok(results)
     }
+
+    /// Searches for files matching the given search string.
+    ///
+    /// This function queries the file search service to retrieve a list of files matching the search string.
+    /// It checks if the search functionality is enabled before proceeding.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ZbusError::Failed` if the search functionality is disabled or if there is
+    /// an error during the retrieval of files.
+    ///
+    /// # Returns
+    ///
+    /// A vector of `FileInfo` representing the matching files if successful.
     pub async fn search_files(&self, search: &str) -> zbus::fdo::Result<Vec<FileInfo>> {
         info!("Search files: {}", search);
         if !self.config.files.enable_search_files {
@@ -111,6 +126,46 @@ impl ServerInterface {
             Err(err) => {
                 error!("Error searching files: {}", err);
                 return Err(ZbusError::Failed("Error searching files".to_string()));
+            }
+        };
+        debug!("result: {:?}", results);
+        Ok(results)
+    }
+
+    /// Searches for app actions matching the given search string.
+    ///
+    /// This function queries the app actions service to retrieve a list of app actions
+    /// matching the search string. It checks if the search functionality is enabled before proceeding.
+    ///
+    /// # Arguments
+    ///
+    /// * `search` - A search string to query app actions.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ZbusError::Failed` if the search functionality is disabled or if there is
+    /// an error during the retrieval of app actions.
+    ///
+    /// # Returns
+    ///
+    /// A vector of `AppActions` representing the matching app actions if successful.
+    pub async fn search_app_actions(&self, search: &str) -> zbus::fdo::Result<Vec<AppActions>> {
+        info!("Search app actions: {}", search);
+        if !self.config.app_actions.enable_search {
+            warn!("Search App Action is disabled");
+            return Err(ZbusError::Failed(
+                "Search App Action is disabled".to_string(),
+            ));
+        }
+        // At some point later: perform a search
+        let results = match self
+            .app_actions_service
+            .search(search, self.config.apps.search_limit)
+        {
+            Ok(results) => results,
+            Err(err) => {
+                error!("Error searching app actions: {}", err);
+                return Err(ZbusError::Failed("Error searching app actions".to_string()));
             }
         };
         debug!("result: {:?}", results);

--- a/mxsearch/src/service.rs
+++ b/mxsearch/src/service.rs
@@ -1,4 +1,5 @@
 use crate::error::ServiceError;
+use app_actions::AppActions;
 use apps::AppInfo;
 use files::FileInfo;
 use log::{debug, info};
@@ -18,6 +19,7 @@ pub trait MxSearch {
     async fn search_applications(&self, search: &str) -> zbus::fdo::Result<Vec<AppInfo>>;
     async fn list_applications(&self) -> zbus::fdo::Result<Vec<AppInfo>>;
     async fn search_files(&self, search: &str) -> zbus::fdo::Result<Vec<FileInfo>>;
+    async fn search_app_actions(&self, search: &str) -> zbus::fdo::Result<Vec<AppActions>>;
 }
 
 impl MxSearchService {
@@ -54,5 +56,11 @@ impl MxSearchService {
         debug!("Connecting to D-Bus session for search_files");
         let files = self.proxy.search_files(search).await?;
         Ok(files)
+    }
+
+    pub async fn search_app_actions(&self, search: &str) -> Result<Vec<AppActions>, anyhow::Error> {
+        debug!("Connecting to D-Bus session for app actions");
+        let app_actions = self.proxy.search_app_actions(search).await?;
+        Ok(app_actions)
     }
 }


### PR DESCRIPTION
### ⚙️ App Actions Search

## Overview

This service indexes configuration schemas into a Tantivy search index.
Each config file is parsed and indexed with its metadata and nested action sections.
It maintains data consistency by using checksum validation to avoid unnecessary re-indexing.

- Applications installed on the system register their **App Actions** to **mxsearch**.
- This allows mxsearch to return App Actions as part of search results.
- App Actions are stored as **TOML** files inside the directory:  
  `/usr/share/mxsearch/actions`