### PR TITLE
fix: replace std thread with thread-pool

### DIFF
--- a/dbus/freedesktop/bluez/Cargo.toml
+++ b/dbus/freedesktop/bluez/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }
 zbus = { version = "5.7.1" }
-futures = "0.3.30"
 thiserror = { version = "2.0.12" }
 async-trait = { version = "0.1.88" }
 log = { version = "0.4.27" }
+futures = { version = "0.3.30", features = ["thread-pool"] }

--- a/dbus/freedesktop/bluez/src/service.rs
+++ b/dbus/freedesktop/bluez/src/service.rs
@@ -27,16 +27,19 @@
 //! This abstraction makes it easy to swap out or mock Bluetooth backends for testing or platform support.
 
 use crate::errors::BluezError;
-use std::sync::mpsc;
+use std::sync::{mpsc, LazyLock};
 
 use super::interfaces::{device::BluetoothDevice, BluezInterface};
 use crate::proxies::BluezProxy;
 use anyhow::Result;
+use futures::executor::ThreadPool;
 use futures::StreamExt;
 use log::{error, info};
 use zbus::export::ordered_stream::OrderedStreamExt;
 use zbus::Connection;
 
+static THREAD_POOL: LazyLock<ThreadPool> =
+    LazyLock::new(|| ThreadPool::new().expect("Failed to build pool"));
 #[derive(Clone)]
 pub struct BluetoothService {
     proxy: BluezProxy<'static>,
@@ -146,26 +149,23 @@ impl BluetoothService {
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
 
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_bluetooth_enabled_status().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                // Blocking send (uses thread park/unpark internally)
-                                if let Err(e) = sender.send(state) {
-                                    error!("failed to send strength event to receiver: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_bluetooth_enabled_status().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            // Blocking send (uses thread park/unpark internally)
+                            if let Err(e) = sender.send(state) {
+                                error!("failed to send strength event to receiver: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("failed to stream bluetooth enabled status: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("failed to stream bluetooth enabled status: {}", e);
+                }
+            }
         });
         receiver
     }
@@ -174,38 +174,35 @@ impl BluetoothService {
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
 
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_bluetooth_events().await {
-                    Ok((mut added, mut removed)) => {
-                        loop {
-                            tokio::select! {
-                                // Handle InterfacesAdded events
-                                Some(_event) = OrderedStreamExt::next(&mut added) => {
-                                    let event = BluetoothEvent::DeviceAdded;
-                                    // Add your device-added logic here
-                                    if let Err(e) = sender.send(event) {
-                                    error!("failed to send device added event to receiver: {}", e);
-                                    continue;
-                                    }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_bluetooth_events().await {
+                Ok((mut added, mut removed)) => {
+                    loop {
+                        tokio::select! {
+                            // Handle InterfacesAdded events
+                            Some(_event) = OrderedStreamExt::next(&mut added) => {
+                                let event = BluetoothEvent::DeviceAdded;
+                                // Add your device-added logic here
+                                if let Err(e) = sender.send(event) {
+                                error!("failed to send device added event to receiver: {}", e);
+                                continue;
                                 }
-                                // Handle InterfacesRemoved events
-                                Some(_event) = OrderedStreamExt::next(&mut removed) => {
-                                    let event = BluetoothEvent::DeviceRemoved;
-                                    if let Err(e) = sender.send(event) {
-                                    error!("failed to send device removed event to receiver: {}", e);
-                                    continue;
-                                    }
-                                }
-                                // Exit condition
-                                else => break,
                             }
+                            // Handle InterfacesRemoved events
+                            Some(_event) = OrderedStreamExt::next(&mut removed) => {
+                                let event = BluetoothEvent::DeviceRemoved;
+                                if let Err(e) = sender.send(event) {
+                                error!("failed to send device removed event to receiver: {}", e);
+                                continue;
+                                }
+                            }
+                            // Exit condition
+                            else => break,
                         }
                     }
-                    Err(e) => error!("Failed to stream events: {}", e),
                 }
-            });
+                Err(e) => error!("Failed to stream events: {}", e),
+            }
         });
         receiver
     }

--- a/dbus/freedesktop/networkmanager/Cargo.toml
+++ b/dbus/freedesktop/networkmanager/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }
 zbus = { version = "5.7.1" }
-futures = "0.3.30"
+futures = { version = "0.3.30", features = ["thread-pool"] }
 thiserror = { version = "2.0.12" }
 async-trait = { version = "0.1.88" }
 log = { version = "0.4.27" }

--- a/dbus/freedesktop/networkmanager/src/service.rs
+++ b/dbus/freedesktop/networkmanager/src/service.rs
@@ -7,10 +7,14 @@ use crate::interfaces::wireless::{
 };
 use crate::proxies::NetworkManagerProxy;
 use anyhow::Result;
-use futures::StreamExt;
+use futures::executor::ThreadPool;
+use futures::{FutureExt, StreamExt};
 use log::{debug, error, info};
-use std::sync::mpsc;
+use std::sync::{mpsc, LazyLock};
 use zbus::Connection;
+
+static THREAD_POOL: LazyLock<ThreadPool> =
+    LazyLock::new(|| ThreadPool::new().expect("Failed to build pool"));
 
 /// A service wrapper for interacting with a NetworkManager implementation.
 ///
@@ -175,26 +179,22 @@ impl NetworkManagerService {
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
 
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_device_events().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                // Blocking send (uses thread park/unpark internally)
-                                if let Err(e) = sender.send(NMState::from(state)) {
-                                    error!("failed to send device event to receiver: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_device_events().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            if let Err(e) = sender.send(NMState::from(state)) {
+                                error!("failed to send device event to receiver: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("Failed to stream to device events: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("Failed to stream to device events: {}", e);
+                }
+            }
         });
         receiver
     }
@@ -205,148 +205,131 @@ impl NetworkManagerService {
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
 
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                let (mut access_point_added_stream, mut access_point_removed_stream) =
-                    match proxy.stream_access_point_events().await {
-                        Ok((added_stream, removed_stream)) => (added_stream, removed_stream),
-                        Err(e) => {
-                            error!("failed to stream to access point events: {}", e);
-                            return;
-                        }
-                    };
-
-                loop {
-                    tokio::select! {
-                        // Handle access point added events
-                        may_be_ap_added = access_point_added_stream.next() => {
-                            if let Some(ap_added) = may_be_ap_added {
-                                let args = match ap_added.args() {
-                                    Ok(args) => args,
-                                    Err(e) => {
-                                        error!("failed to get access point added args: {}", e);
-                                        continue; // Skip this item
-                                    }
-                                };
-                                let access_point_path = args.access_point.to_string();
-                                info!("access point added: {}", access_point_path);
-
-                                let raw_access_point_info = match proxy.get_access_point_info(&args.access_point).await {
-                                    Ok(info) => info,
-                                    Err(e) => {
-                                        error!("failed to get access point info: {}", e);
-                                        continue; // Skip this item
-                                    }
-                                };
-
-                                let access_point_event_info = AccessPointEvent {
-                                    access_point_path,
-                                    event_type: EventType::Added,
-                                    raw_access_point_info: Some(raw_access_point_info),
-                                    ..Default::default()
-                                };
-
-                                // Forward object path to the channel
-                                if sender.send(Ok(access_point_event_info)).is_err() {
-                                    error!("failed to send access point added: receiver dropped");
-                                    continue; // Receiver dropped
-                                }
-                            } else {
-                                continue; // Stream ended
-                            }
-                        }
-
-                        // Handle access point removed events
-                        may_be_ap_removed = access_point_removed_stream.next() => {
-                            if let Some(ap_removed) = may_be_ap_removed {
-                                println!("ap removed");
-                                let args = match ap_removed.args() {
-                                    Ok(args) => args,
-                                    Err(e) => {
-                                        error!("failed to get access point removed args: {}", e);
-                                        continue; // Skip this item
-                                    }
-                                };
-                                let access_point_path = args.access_point.to_string();
-                                debug!("access point removed: {}", access_point_path);
-
-                                let access_point_event_info = AccessPointEvent {
-                                    access_point_path,
-                                    event_type: EventType::Removed,
-                                    raw_access_point_info: None,
-                                    ..Default::default()
-                                };
-                                println!("event to send back: {:?}", access_point_event_info);
-
-                                // Forward object path to the channel
-                                if sender.send(Ok(access_point_event_info)).is_err() {
-                                    error!("failed to send access point added: receiver dropped");
-                                    continue; // Receiver dropped
-                                }
-                            } else {
-                                continue; // Stream ended
-                            }
-                        }
+        THREAD_POOL.spawn_ok(async move {
+            let (mut access_point_added_stream, mut access_point_removed_stream) =
+                match proxy.stream_access_point_events().await {
+                    Ok((added_stream, removed_stream)) => (added_stream, removed_stream),
+                    Err(e) => {
+                        error!("failed to stream to access point events: {}", e);
+                        return;
                     }
+                };
+
+            loop {
+                futures::select_biased! {
+                    may_be_ap_added = access_point_added_stream.next().fuse() => {
+                        if let Some(ap_added) = may_be_ap_added {
+                            let args = match ap_added.args() {
+                                Ok(args) => args,
+                                Err(e) => {
+                                    error!("failed to get access point added args: {}", e);
+                                    continue; // Skip this item
+                                }
+                            };
+                            let access_point_path = args.access_point.to_string();
+                            info!("access point added: {}", access_point_path);
+
+                            let raw_access_point_info = match proxy.get_access_point_info(&args.access_point).await {
+                                Ok(info) => info,
+                                Err(e) => {
+                                    error!("failed to get access point info: {}", e);
+                                    continue; // Skip this item
+                                }
+                            };
+
+                            let access_point_event_info = AccessPointEvent {
+                                access_point_path,
+                                event_type: EventType::Added,
+                                raw_access_point_info: Some(raw_access_point_info),
+                                ..Default::default()
+                            };
+
+                            if sender.send(Ok(access_point_event_info)).is_err() {
+                                error!("failed to send access point added: receiver dropped");
+                                continue; // Receiver dropped
+                            }
+                        } else {
+                            continue; // Stream ended
+                        }
+                    },
+                    may_be_ap_removed = access_point_removed_stream.next().fuse() => {
+                        if let Some(ap_removed) = may_be_ap_removed {
+                            let args = match ap_removed.args() {
+                                Ok(args) => args,
+                                Err(e) => {
+                                    error!("failed to get access point removed args: {}", e);
+                                    continue; // Skip this item
+                                }
+                            };
+                            let access_point_path = args.access_point.to_string();
+                            debug!("access point removed: {}", access_point_path);
+
+                            let access_point_event_info = AccessPointEvent {
+                                access_point_path,
+                                event_type: EventType::Removed,
+                                raw_access_point_info: None,
+                                ..Default::default()
+                            };
+
+                            if sender.send(Ok(access_point_event_info)).is_err() {
+                                error!("failed to send access point added: receiver dropped");
+                                continue; // Receiver dropped
+                            }
+                        } else {
+                            continue; // Stream ended
+                        }
+                    },
                 }
-            });
+            }
         });
         receiver
     }
     pub async fn stream_wireless_enabled_status(&self) -> mpsc::Receiver<bool> {
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
-
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_wireless_enabled_status().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                info!("state updated: {}", state);
-                                // Blocking send (uses thread park/unpark internally)
-                                if let Err(e) = sender.send(state) {
-                                    error!("failed to send device event to receiver: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_wireless_enabled_status().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            info!("state updated: {}", state);
+                            if let Err(e) = sender.send(state) {
+                                error!("failed to send device event to receiver: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("Failed to stream to device events: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("Failed to stream to device events: {}", e);
+                }
+            }
         });
         receiver
     }
     pub async fn stream_active_network_strength(&self) -> mpsc::Receiver<u8> {
+        println!("service-action:: streaming active network strength");
         info!("service-action:: streaming active network strength");
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
 
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_wireless_network_strength().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                // Blocking send (uses thread park/unpark internally)
-                                if let Err(e) = sender.send(state) {
-                                    error!("failed to send strength event to receiver: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_wireless_network_strength().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            info!("network strength updated: {}", state);
+                            if let Err(e) = sender.send(state) {
+                                error!("failed to send strength event to receiver: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("Failed to stream to device events: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("Failed to stream to device events: {}", e);
+                }
+            }
         });
         receiver
     }

--- a/dbus/freedesktop/upower/Cargo.toml
+++ b/dbus/freedesktop/upower/Cargo.toml
@@ -12,9 +12,8 @@ keywords.workspace = true
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1", features = ["full"] }
 zbus = { version = "5.7.1" }
-futures = "0.3.30"
+futures = { version = "0.3.30", features = ["thread-pool"] }
 thiserror = { version = "2.0.12" }
 async-trait = { version = "0.1.88" }
 log = { version = "0.4.27" }

--- a/dbus/freedesktop/upower/src/service.rs
+++ b/dbus/freedesktop/upower/src/service.rs
@@ -8,19 +8,21 @@ use crate::interfaces::device::{BatteryLevel, BatteryState, PowerSourceType, War
 use crate::interfaces::UPowerInterface;
 use crate::proxies::DeviceProxy;
 use anyhow::Result;
+use futures::executor::ThreadPool;
 use futures::StreamExt;
 use log::{error, info};
-use std::sync::mpsc;
+use std::sync::{mpsc, LazyLock};
 use zbus::Connection;
 
+static THREAD_POOL: LazyLock<ThreadPool> =
+    LazyLock::new(|| ThreadPool::new().expect("Failed to build pool"));
 /// A service wrapper providing convenient methods for accessing UPower device data.
 ///
 /// This struct is generic over any type implementing the [`UpowerInterface`] trait,
 /// allowing for flexible backends (e.g., real D-Bus proxy or a mock for testing).
 #[derive(Clone)]
-pub struct UPowerService<> {
+pub struct UPowerService {
     proxy: DeviceProxy<'static>,
-
 }
 
 impl UPowerService {
@@ -132,27 +134,23 @@ impl UPowerService {
         info!("service-action:: stream device state");
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
-
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_device_state().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                let state = BatteryState::from(state);
-                                if let Err(e) = sender.send(state) {
-                                    error!("failed to send battery state: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_device_state().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            let state = BatteryState::from(state);
+                            if let Err(e) = sender.send(state) {
+                                error!("failed to send battery state: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("Failed to stream to device state events: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("Failed to stream to device state events: {}", e);
+                }
+            }
         });
         receiver
     }
@@ -160,26 +158,22 @@ impl UPowerService {
         info!("service-action:: stream device percentage");
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
-
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_device_percentage().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                if let Err(e) = sender.send(state) {
-                                    error!("failed to send device percentage: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_device_percentage().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            if let Err(e) = sender.send(state) {
+                                error!("failed to send device percentage: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("Failed to stream to device percentage: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("Failed to stream to device percentage: {}", e);
+                }
+            }
         });
         receiver
     }
@@ -187,26 +181,24 @@ impl UPowerService {
         info!("service-action:: stream battery level");
         let proxy = self.proxy.clone();
         let (sender, receiver) = mpsc::channel();
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                match proxy.stream_battery_level().await {
-                    Ok(mut stream) => {
-                        while let Some(event) = stream.next().await {
-                            if let Ok(state) = event.get().await {
-                                let state = BatteryLevel::from(state);
-                                if let Err(e) = sender.send(state) {
-                                    error!("failed to send battery level: {}", e);
-                                    continue;
-                                }
+        THREAD_POOL.spawn_ok(async move {
+            match proxy.stream_battery_level().await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if let Ok(state) = event.get().await {
+                            info!("battery level is updated: {:}", state);
+                            let state = BatteryLevel::from(state);
+                            if let Err(e) = sender.send(state) {
+                                error!("failed to send battery level: {}", e);
+                                continue;
                             }
                         }
                     }
-                    Err(e) => {
-                        error!("Failed to stream to device percentage: {}", e);
-                    }
                 }
-            });
+                Err(e) => {
+                    error!("Failed to stream to device percentage: {}", e);
+                }
+            }
         });
         receiver
     }


### PR DESCRIPTION
### Fixes

The previous use of `std` threads was blocking native OS threads, which caused UI blocking issues. This has been fixed by replacing them with a **general-purpose thread pool** that schedules tasks polling futures to completion.

The implementation now employs the `ThreadPool` from the `futures` crate, providing efficient async task management without blocking the UI.

Reference: [futures::executor::ThreadPool](https://docs.rs/futures/latest/futures/executor/struct.ThreadPool.html)
