### PR TITLE
refactor(service-plugins): bevy version replaced with workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ bevy = { version = "0.16.1", default-features = false, features = [
     "default_font",
     "bevy_state",
     "png",
-    "bevy_ui_picking_backend",
+    "bevy_mesh_picking_backend",
     "bevy_input_focus",
 ] }
 bevy_wayland = { git = "https://github.com/mecha-org/bevy_wayland.git", rev = "a91508672e2beecffd065984c94d9d493b3eaf4e" }

--- a/shell/crates/service_plugins/Cargo.toml
+++ b/shell/crates/service_plugins/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-bevy = { version = "0.16.0-dev" }
+bevy = { workspace = true }
 libpulse-binding = "2.30.1"
 networkmanager = { path = "../../../dbus/freedesktop/networkmanager" }
 bluez = { path = "../../../dbus/freedesktop/bluez" }


### PR DESCRIPTION
## Bevy Version
Bevy dependency in plugins replaced with workspace version so that we can use avoid version issue later