### PR TITLE
feat: adds mechanix-extension-service 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "services/conf",
     "services/system",
     "services/search/*",
+    "services/extensions",
     "shell/crates/*",
     "shared/hw-buttons",
     "dbus/freedesktop/*",

--- a/dbus/mechanix/extensions/examples/reciever.rs
+++ b/dbus/mechanix/extensions/examples/reciever.rs
@@ -1,67 +1,27 @@
-use tokio;
 use extensions::proxy::reciever::ExtensionServiceReceiver;
 use extensions::events::ExtensionServiceEvent;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Starting ExtensionService receiver client...");
-
-    // Create receiver and get the event channel
+    // Create receiver and get event channel
     let (receiver, mut event_receiver) = ExtensionServiceReceiver::new().await?;
-
-    // Start the receiver service in a background task
-    let receiver_task = tokio::spawn(async move {
-        if let Err(e) = receiver.start_service().await {
-            eprintln!("Receiver service failed: {}", e);
-        }
+    
+    // Start receiver in background
+    tokio::spawn(async move {
+        receiver.start_service().await.ok();
     });
-
-    // Handle events from the receiver
-    let event_handler_task = tokio::spawn(async move {
-        println!("Waiting for ExtensionServiceEvents...");
-        
-        while let Some(event) = event_receiver.recv().await {
-            match event {
-                ExtensionServiceEvent::Added(device) => {
-                    println!("📦 ExtensionServiceEvent::Added received!");
-                    println!("  Device: {}", device.name());
-                    println!("  Path: {:?}", device.path());
-                    println!("  Type: {:?}", device.device_type());
-                    println!("  Connection: {:?}", device.connection_type());
-                    println!("  Vendor ID: 0x{:04x}", device.vendor_id());
-                    println!("  Unique ID: {}", device.unique_id());
-                    println!("  ---");
-                }
-                ExtensionServiceEvent::Removed(device) => {
-                    println!("📦 ExtensionServiceEvent::Removed received!");
-                    println!("  Device: {}", device.name());
-                    println!("  Path: {:?}", device.path());
-                    println!("  ---");
-                }
+    
+    // Listen for signals
+    while let Some(event) = event_receiver.recv().await {
+        match event {
+            ExtensionServiceEvent::Added(device) => {
+                println!("Device added: {}", device.name());
             }
-        }
-        
-        println!("Event receiver stream ended");
-    });
-
-    println!("ExtensionService receiver is running...");
-    println!("Press Ctrl+C to stop");
-
-    // Wait for either task to complete
-    tokio::select! {
-        result = receiver_task => {
-            match result {
-                Ok(_) => println!("Receiver task completed"),
-                Err(e) => eprintln!("Receiver task failed: {}", e),
-            }
-        }
-        result = event_handler_task => {
-            match result {
-                Ok(_) => println!("Event handler task completed"),
-                Err(e) => eprintln!("Event handler task failed: {}", e),
+            ExtensionServiceEvent::Removed(device) => {
+                println!("Device removed: {}", device.name());
             }
         }
     }
-
+    
     Ok(())
 }

--- a/dbus/mechanix/extensions/src/detection/service.rs
+++ b/dbus/mechanix/extensions/src/detection/service.rs
@@ -2,7 +2,6 @@ use evdevil::{ enumerate_hotplug, Evdev };
 use tokio::sync::mpsc;
 use tokio::task;
 use evdev::KeyCode;
-use evdev::EventSummary::Key;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use crate::events::ExtensionServiceEvent;

--- a/dbus/mechanix/extensions/src/device/mod.rs
+++ b/dbus/mechanix/extensions/src/device/mod.rs
@@ -4,9 +4,7 @@ use zvariant::{ Type };
 use serde::{ Serialize, Deserialize };
 use types::{ DeviceType, ConnectionType };
 use evdevil::Evdev;
-use evdev::EventSummary::Key;
 use std::path::PathBuf;
-use std::{ collections::HashSet, fs };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct Device {

--- a/dbus/mechanix/extensions/src/device/types.rs
+++ b/dbus/mechanix/extensions/src/device/types.rs
@@ -2,7 +2,6 @@ use evdevil::{ Evdev, Bus };
 use evdevil::event::{ EventType, Key, Switch };
 use serde::{ Deserialize, Serialize };
 use zvariant::{ Type };
-use anyhow::Result;
 use toml;
 use std::fs;
 use std::env;

--- a/dbus/mechanix/extensions/src/device/types.rs
+++ b/dbus/mechanix/extensions/src/device/types.rs
@@ -5,6 +5,8 @@ use zvariant::{ Type };
 use anyhow::Result;
 use toml;
 use std::fs;
+use std::env;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq)]
 pub enum DeviceType {
@@ -156,20 +158,20 @@ impl ConnectionType {
 }
 
 fn is_extension(id: String) -> Option<String> {
-    match fs::read_to_string("./config.toml") {
+    // Get config path from environment variable or use default
+    let config_path = env::var("MECHANIX_EXTENSION_CONFIG_PATH")
+        .unwrap_or_else(|_| {
+            let mut path = PathBuf::from(env::var("HOME").unwrap_or_else(|_| ".".to_string()));
+            path.push(".config/mechanix/extensions/config.toml");
+            path.to_string_lossy().to_string()
+        });
+
+    match fs::read_to_string(&config_path) {
         Ok(raw) => {
             match toml::from_str::<ExtensionConfig>(&raw) {
                 Ok(cfg) => {
                     for ext in cfg.extensions {
                         if ext.unique_id == id {
-                            // Parse the connection_key string to KeyCode
-                            // match KeyCode::from_str(&ext.connection_key) {
-                            //     Ok(key_code) => return Some(key_code),
-                            //     Err(e) => {
-                            //         println!("Error parsing connection key '{}': {}", ext.connection_key, e);
-                            //         return None;
-                            //     }
-                            // }
                             return Some(ext.connection_key);
                         }
                     }
@@ -182,7 +184,7 @@ fn is_extension(id: String) -> Option<String> {
             }
         }
         Err(e) => {
-            println!("Error reading file: {}", e);
+            println!("Error reading config file '{}': {}", config_path, e);
             None
         }
     }

--- a/dbus/mechanix/extensions/src/interface/mod.rs
+++ b/dbus/mechanix/extensions/src/interface/mod.rs
@@ -1,4 +1,3 @@
-use evdevil;
 use zbus::{ interface, Connection, object_server::SignalEmitter };
 use tokio::{ sync::mpsc::{ Receiver, Sender, channel } };
 use crate::errors::{ Result, Error };

--- a/dbus/mechanix/extensions/src/proxy/reciever.rs
+++ b/dbus/mechanix/extensions/src/proxy/reciever.rs
@@ -1,5 +1,4 @@
 use crate::events::ExtensionServiceEvent;
-use crate::device::Device;
 use crate::proxy::extensions::ExtensionServiceProxy;
 use zbus::Connection;
 use futures_lite::stream::StreamExt;

--- a/services/extensions/Cargo.toml
+++ b/services/extensions/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "mechanix-extension-service"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+categories.workspace = true
+keywords.workspace = true
+
+[dependencies]
+tokio = {workspace = true}
+extensions = {path = "../../dbus/mechanix/extensions"}
+anyhow = { workspace = true }
+log = { workspace = true }
+env_logger = {workspace = true}
+
+[package.metadata.deb]
+maintainer = "Sandeep Patel <mineshp@mechasystems.com>"
+extended-description = """\
+Detection Service for the Mechanix Extensions"""
+depends = "$auto"
+section = "utility"
+priority = "optional"
+assets = [
+    # target/release path is special, and gets replaced by cargo-deb with the actual target dir path.
+    [
+        "../../target/release/mechanix-extension-service",
+        "usr/bin/",
+        "755",
+    ],
+]

--- a/services/extensions/README.md
+++ b/services/extensions/README.md
@@ -1,0 +1,26 @@
+# Mechanix Extension Service
+
+A D-Bus service for detecting and managing extensions in the Mechanix GUI system.
+
+## Overview
+
+This service provides extension detection capabilities and exposes functionality through D-Bus interface for communication with other Mechanix components.
+
+## Building
+
+```bash
+cargo build --release
+```
+
+## Running
+
+```bash
+cargo run
+```
+
+## Features
+
+- Extension detection and management
+- D-Bus interface for inter-process communication
+- Graceful shutdown handling
+- Comprehensive error handling and logging

--- a/services/extensions/src/main.rs
+++ b/services/extensions/src/main.rs
@@ -1,0 +1,37 @@
+use tokio;
+use extensions::interface::ExtensionService;
+use anyhow::Result;
+use log::{error, info, warn};
+use std::process;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging with better error handling
+    if let Err(e) = env_logger::try_init() {
+        eprintln!("Failed to initialize logger: {}", e);
+        process::exit(1);
+    }
+
+    info!("Starting Extension Service...");
+
+    tokio::select! {
+        result = ExtensionService::start_service() => {
+            match result {
+                Ok(_) => {
+                    info!("Extension service completed successfully");
+                }
+                Err(e) => {
+                    error!("Extension service failed: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            warn!("Received shutdown signal, stopping extension service...");
+            info!("Extension service stopped gracefully");
+            process::exit(0);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
config.toml is read from : `MECHANIX_EXTENSION_CONFIG_PATH` and defaults to ~/.config/mechanix/extensions/config.toml

**Build the binray in workspace**
```
cargo build --release --package mechanix-extension-service
```
