### PR TITLE
feat: remove media kit

### DIFF
--- a/apps/notes/debian/control
+++ b/apps/notes/debian/control
@@ -1,5 +1,5 @@
 Package: mechanix-notes-beta
-Version: 0.0.2
+Version: 0.0.3
 Maintainer: Dhanish Patel <dhanishp@mechasystems.com>
 Description: Mechanix Notes app
   A notes application for Mechanix OS, allowing users to create, edit, and manage their notes seamlessly.

--- a/apps/notes/lib/main.dart
+++ b/apps/notes/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:mechanix_notes/src/constants/constants.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:mechanix_notes/src/features/search_notes/presentation/search_notes.dart';
-import 'package:media_kit/media_kit.dart';
+// import 'package:media_kit/media_kit.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:widgets/mechanix.dart';
 import 'package:watch_it/watch_it.dart';
@@ -23,7 +23,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeHive();
   Hive.registerAdapter(NoteHiveAdapter());
-  MediaKit.ensureInitialized();
+  // MediaKit.ensureInitialized();
 
   await Hive.openBox<NoteHive>(Constants.tableName);
   runApp(

--- a/apps/notes/pubspec.yaml
+++ b/apps/notes/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
Removed the media kit to measure and validate the app opening time for the Notes app.
