### PR TITLE
fix(files): media kit initialization

### DIFF
--- a/apps/files/debian/control
+++ b/apps/files/debian/control
@@ -1,5 +1,5 @@
 Package: mechanix-files-beta
-Version: 0.0.4
+Version: 0.0.5
 Maintainer: Yogita Hiray <yogitah@mechasystems.com>
 Description: Mechanix Files app
   A file management application for Mechanix OS, enabling users to browse, organize, and manage their files effortlessly.

--- a/apps/files/devtools_options.yaml
+++ b/apps/files/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/apps/files/lib/main.dart
+++ b/apps/files/lib/main.dart
@@ -10,7 +10,6 @@ import 'package:mechanix_files/src/features/files/data/file_repository.dart';
 import 'package:mechanix_files/src/features/files/data/file_repository_impl.dart';
 import 'package:mechanix_files/src/features/files/data/recent_file_manager_repository.dart';
 import 'package:mechanix_files/src/features/files/presentation/files_home.dart';
-import 'package:media_kit/media_kit.dart';
 import 'package:watch_it/watch_it.dart';
 import 'package:widgets/mechanix.dart';
 
@@ -20,7 +19,6 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final configResult = await connectToMxconf(); // Await the Future properly
   AppConfig().loadFromMap(configResult); // Load into singleton instance
-  MediaKit.ensureInitialized();
 
   runApp(
     MultiBlocProvider(

--- a/apps/files/lib/src/features/preview/presentation/audio_player.dart
+++ b/apps/files/lib/src/features/preview/presentation/audio_player.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:mechanix_files/src/services/media_kit_manager.dart';
 import 'package:media_kit/media_kit.dart';
 
 class AudioPlayerOverlay extends StatefulWidget {
@@ -23,8 +24,12 @@ class _AudioPlayerOverlayState extends State<AudioPlayerOverlay> {
   @override
   void initState() {
     super.initState();
-    player = Player();
+    _initializePlayer();
+  }
 
+  Future<void> _initializePlayer() async {
+    await MediaKitManager.init();
+    player = Player();
     player.open(Media(widget.filePath));
 
     _playingSub = player.stream.playing.listen((playing) {

--- a/apps/files/lib/src/features/preview/presentation/video_player.dart
+++ b/apps/files/lib/src/features/preview/presentation/video_player.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:mechanix_files/src/services/media_kit_manager.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
@@ -23,7 +24,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
   bool _controlsVisible = true;
   Timer? _hideControlsTimer;
 
-  bool _showOptions = false;
+  final bool _showOptions = false;
   double _playbackRate = 1.0;
   ZoomMode _zoomMode = ZoomMode.original;
 
@@ -38,37 +39,37 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   double _localVolume = 50; // Default volume at 50%
   bool _isPlayerDisposed = false;
+  bool _isInitialized = false;
 
   @override
   void initState() {
     super.initState();
+    _initializePlayer();
+  }
+
+  Future<void> _initializePlayer() async {
+    await MediaKitManager.init();
     player = Player();
     videoController = VideoController(player);
-    player.open(Media(widget.filePath));
+    await player.open(Media(widget.filePath));
 
-    // Listen to position changes and total duration changes
     _positionSub = player.stream.position.listen((position) {
       if (!mounted) return;
-      setState(() {
-        _currentPosition = position;
-      });
+      setState(() => _currentPosition = position);
     });
 
     _durationSub = player.stream.duration.listen((duration) {
       if (!mounted) return;
-      setState(() {
-        _totalDuration = duration ?? Duration.zero;
-      });
+      setState(() => _totalDuration = duration ?? Duration.zero);
     });
 
     _playingSub = player.stream.playing.listen((playing) {
       if (!mounted) return;
-      setState(() {
-        _isPlaying = playing;
-      });
+      setState(() => _isPlaying = playing);
     });
 
-    _startHideTimer();
+    if (!mounted) return;
+    setState(() => _isInitialized = true);
   }
 
   void _startHideTimer() {
@@ -133,6 +134,12 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
+    if (!_isInitialized) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
       body: Listener(
         behavior: HitTestBehavior.opaque, // ensures all taps are detected

--- a/apps/files/lib/src/services/media_kit_manager.dart
+++ b/apps/files/lib/src/services/media_kit_manager.dart
@@ -1,0 +1,12 @@
+import 'package:media_kit/media_kit.dart';
+
+class MediaKitManager {
+  static bool _initialized = false;
+
+  static Future<void> init() async {
+    if (!_initialized) {
+      MediaKit.ensureInitialized();
+      _initialized = true;
+    }
+  }
+}

--- a/apps/files/pubspec.yaml
+++ b/apps/files/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
- Removed Media Kit initialization from app startup.
- Media Kit initialization is now performed inside the AudioPlayer, VideoPlayer.
- Ensures initialization happens only once using a static flag