### PR TITLE
fix(settings): use MaterialPageRoute for wireless network navigation

### DIFF
--- a/apps/settings/lib/main.dart
+++ b/apps/settings/lib/main.dart
@@ -107,23 +107,25 @@ class MechanixSettingsApp extends StatelessWidget with WatchItMixin {
         watchPropertyValue((ThemeToggle t) => t.mechanixVariant);
 
     return MechanixTheme(
-      data: MechanixThemeData(mechanixVariant: mechanixVariant, extensions: const [
-        MechanixNavigationBarThemeData(
-          scrolledUnderElevation: 0,
-          titleStyle: TextStyle(
-            fontSize: 24,
-          ),
-          titleSpacing: 0,
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-        ),
-        MechanixSwitchThemeData(
-          style: MechanixSwitchStyle(
-            inactiveThumbColor: Color(0xFF989898),
-            inactiveTrackColor: Color(0xFF252525),
-          ),
-        ),
-      ]),
+      data: MechanixThemeData(
+          mechanixVariant: mechanixVariant,
+          extensions: const [
+            MechanixNavigationBarThemeData(
+              scrolledUnderElevation: 0,
+              titleStyle: TextStyle(
+                fontSize: 24,
+              ),
+              titleSpacing: 0,
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+            ),
+            MechanixSwitchThemeData(
+              style: MechanixSwitchStyle(
+                inactiveThumbColor: Color(0xFF989898),
+                inactiveTrackColor: Color(0xFF252525),
+              ),
+            ),
+          ]),
       builder: (context, mechanix, child) => MainApp(
         darkTheme: mechanix.darkTheme,
         lightTheme: mechanix.lightTheme,
@@ -156,13 +158,6 @@ class MainApp extends StatelessWidget {
                 ..add(InitializeSound())
                 ..add(GetOutputDeviceList())
                 ..add(GetInputDeviceList()),
-        ),
-
-        // Wireless Bloc
-        BlocProvider(
-          create: (context) => WirelessSettingsBloc(
-              wifiRepository: context.read<WifiRepository>())
-            ..add(InitWifi()),
         ),
 
         // Bluetooth Bloc
@@ -206,7 +201,7 @@ class MainApp extends StatelessWidget {
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        home: SettingMenu(),
+        home: const SettingMenu(),
         theme: lightTheme,
         darkTheme: darkTheme.copyWith(
           scaffoldBackgroundColor: Colors.black,
@@ -224,28 +219,41 @@ class MainApp extends StatelessWidget {
           AppRoutes.notificationSound: (context) => const NotificationSound(),
 
           // Wireless Routes
-          AppRoutes.wireless: (context) => const WirelessSettings(),
-          AppRoutes.wirelessNetworkDetails: (context) => const NetworkDetails(),
-          // TODO: for route level bloc 
-          // AppRoutes.wireless: (context) => BlocProvider(
-          //       create: (context) => WirelessSettingsBloc(
-          //         wifiRepository: context.read<WifiRepository>(),
-          //       )..add(InitWifi()),
-          //       child: const WirelessSettings(),
-          //     ),
-          // AppRoutes.wirelessNetworkDetails: (context) => BlocProvider.value(  // make common widget 
-          //       value: context.read<WirelessSettingsBloc>(),
-          //       child: const NetworkDetails(),
-          //     ),
+          AppRoutes.wireless: (context) => BlocProvider(
+                create: (context) => WirelessSettingsBloc(
+                  wifiRepository: context.read<WifiRepository>(),
+                )..add(InitWifi()),
+                lazy: false,
+                child: const WirelessSettings(),
+              ),
+          AppRoutes.wirelessNetworkDetails: (context) => BlocProvider.value(
+                // make common widget
+                value: context.read<WirelessSettingsBloc>(),
+                child: const NetworkDetails(),
+              ),
           AppRoutes.ipSettings: (context) => const IpSettings(),
           AppRoutes.ethernetDetails: (context) => const EthernetSettings(),
           AppRoutes.dnsDetails: (context) => const DnsSettings(),
-          AppRoutes.wirelessNetworkSettings: (context) => const NetworkSettings(),
+          AppRoutes.wirelessNetworkSettings: (context) => BlocProvider.value(
+                value: context.read<WirelessSettingsBloc>(),
+                child: const NetworkSettings(),
+              ),
           AppRoutes.wirelessSavedNetworkDetails: (context) =>
-              const SavedNetworkDetails(),
+              BlocProvider.value(
+                value: context.read<WirelessSettingsBloc>(),
+                child: const SavedNetworkDetails(network: null),
+              ),
           AppRoutes.wirelessConnectSecureNetwork: (context) =>
-              const ConnectSecureNetwork(),
-          AppRoutes.wirelessConnectHiddenNetwork: (context) => const AddNetwork(),
+              // const ConnectSecureNetwork(),
+              BlocProvider.value(
+                value: context.read<WirelessSettingsBloc>(),
+                child: const ConnectSecureNetwork(),
+              ),
+          AppRoutes.wirelessConnectHiddenNetwork: (context) =>
+              BlocProvider.value(
+                value: context.read<WirelessSettingsBloc>(),
+                child: const AddNetwork(),
+              ),
           AppRoutes.configureDNS: (context) => const ConfigureDnsWidget(),
           AppRoutes.configureProxy: (context) => const ConfigureProxyWidget(),
           AppRoutes.ipv4Address: (context) => const Ipv4AddressWidget(),
@@ -253,7 +261,8 @@ class MainApp extends StatelessWidget {
 
           // Bluetooth Routes
           AppRoutes.bluetooth: (context) => const Bluetooth(),
-          AppRoutes.bluetoothDeviceInfo: (context) => const BluetoothDeviceInfo(),
+          AppRoutes.bluetoothDeviceInfo: (context) =>
+              const BluetoothDeviceInfo(),
           AppRoutes.adapterSettings: (context) => const AdapterSettings(),
           AppRoutes.adapterRename: (context) => const RenameAdapter(),
           AppRoutes.bluetoothDiscoverable: (context) =>
@@ -268,7 +277,8 @@ class MainApp extends StatelessWidget {
           AppRoutes.display: (context) => const DisplayPage(),
           AppRoutes.appearance: (context) => const Appearance(),
           AppRoutes.applyWallpaper: (context) => const ApplyWallpaper(),
-          AppRoutes.displayScreenOffTime: (context) => const ScreenOffTimeSettings(),
+          AppRoutes.displayScreenOffTime: (context) =>
+              const ScreenOffTimeSettings(),
           AppRoutes.lockScreenTimeout: (context) => const LockScreenTimeout(),
 
           // Other Routes

--- a/apps/settings/lib/src/features/network/blocs/connectNetworkBloc.dart
+++ b/apps/settings/lib/src/features/network/blocs/connectNetworkBloc.dart
@@ -14,7 +14,7 @@ class ConnectNetworkBloc
   StreamSubscription? _wifiStateAndReason;
 
   ConnectNetworkBloc({required this.wifiRepository})
-      : super(ConnectNetworkState()) {
+      : super(const ConnectNetworkState()) {
     on<PasswordChanged>(passwordChanged);
     on<UsernameChanged>(usernameChanged);
     on<TogglePasswordVisibility>(togglePasswordVisibility);

--- a/apps/settings/lib/src/features/network/presentation/connect_secure_network.dart
+++ b/apps/settings/lib/src/features/network/presentation/connect_secure_network.dart
@@ -12,15 +12,14 @@ import 'package:nm/nm.dart';
 import 'package:widgets/mechanix.dart';
 
 class ConnectSecureNetwork extends StatelessWidget {
-  const ConnectSecureNetwork({super.key});
+  const ConnectSecureNetwork({
+    this.accessPoint,
+    super.key});
+
+  final NetworkManagerAccessPoint? accessPoint;
 
   @override
   Widget build(BuildContext context) {
-    final args =
-        ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
-    final NetworkManagerAccessPoint accessPoint =
-        args['accessPoint'] as NetworkManagerAccessPoint;
-
     final wifiRepository = context.read<WifiRepository>();
 
     // void backNavigation(BuildContext context) {
@@ -90,7 +89,7 @@ class ConnectSecureNetwork extends StatelessWidget {
               appBar: PreferredSize(
                   preferredSize: const Size.fromHeight(52),
                   child: MechanixNavigationBar(
-                      title: "Join ${utf8.decode(accessPoint.ssid)}",
+                      title: "Join ${utf8.decode(accessPoint!.ssid)}",
                       actionWidgets: [
                         IconButton(
                           icon: Image.asset(
@@ -103,7 +102,7 @@ class ConnectSecureNetwork extends StatelessWidget {
                               ? () {
                                   context
                                       .read<ConnectNetworkBloc>()
-                                      .add(ConnectToNetwork(accessPoint));
+                                      .add(ConnectToNetwork(accessPoint!));
                                 }
                               : null,
                         ),
@@ -133,7 +132,7 @@ class ConnectSecureNetwork extends StatelessWidget {
                                       state.password.length >= 8) {
                                     context
                                         .read<ConnectNetworkBloc>()
-                                        .add(ConnectToNetwork(accessPoint));
+                                        .add(ConnectToNetwork(accessPoint!));
                                   }
                                 },
                                 validator: (value) {

--- a/apps/settings/lib/src/features/network/presentation/network_details.dart
+++ b/apps/settings/lib/src/features/network/presentation/network_details.dart
@@ -2,17 +2,18 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:mechanix_settings/app_route.dart';
 import 'package:mechanix_settings/src/commons/constants.dart';
 import 'package:mechanix_settings/src/commons/customWidgets/custom_container.dart';
 import 'package:mechanix_settings/src/commons/customWidgets/custom_icon.dart';
 import 'package:mechanix_settings/src/commons/customWidgets/custom_text_button.dart';
 import 'package:mechanix_settings/src/commons/customWidgets/custom_trailing_text.dart';
 import 'package:mechanix_settings/src/commons/styles/color.dart';
+import 'package:mechanix_settings/src/features/network/blocs/connectNetworkBloc.dart';
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_bloc.dart';
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_event.dart';
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_state.dart';
 import 'package:mechanix_settings/src/features/network/models/access_points.dart';
+import 'package:mechanix_settings/src/features/network/presentation/connect_secure_network.dart';
 import 'package:widgets/mechanix.dart';
 import 'package:widgets/widgets/sectionList/mechanix_section_list_theme.dart';
 import 'package:widgets/widgets/sectionList/section_list_items_type.dart';
@@ -311,13 +312,19 @@ Future<void> onNetworkTap(
     context
         .read<WirelessSettingsBloc>()
         .add(ConnectSavedNetwork('', selectedAccessPoint.nmAccessPoint));
-    print('Connecting to saved network... Redirect to back');
     Navigator.pop(context);
   } else {
-    Navigator.pushNamed(
+    final bloc = context.read<ConnectNetworkBloc>();
+
+    Navigator.push(
       context,
-      AppRoutes.wirelessConnectSecureNetwork,
-      arguments: {'accessPoint': selectedAccessPoint?.nmAccessPoint},
+      MaterialPageRoute(
+        builder: (context) => BlocProvider.value(
+          value: bloc,
+          child: ConnectSecureNetwork(
+              accessPoint: selectedAccessPoint?.nmAccessPoint),
+        ),
+      ),
     );
   }
 }

--- a/apps/settings/lib/src/features/network/presentation/network_settings.dart
+++ b/apps/settings/lib/src/features/network/presentation/network_settings.dart
@@ -11,6 +11,7 @@ import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_b
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_event.dart';
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_state.dart';
 import 'package:mechanix_settings/src/features/network/models/saved_networks.dart';
+import 'package:mechanix_settings/src/features/network/presentation/saved_network_details.dart';
 import 'package:mechanix_settings/src/features/network/presentation/wireless.dart';
 import 'package:nm/nm.dart';
 import 'package:widgets/mechanix.dart';
@@ -30,12 +31,17 @@ class _NetworkSettingsState extends State<NetworkSettings> {
     context.read<WirelessSettingsBloc>().add(GetSavedNetworksEvent());
   }
 
-
   void onItemTap(SavedWirelessNetwork network) {
-    Navigator.pushNamed(
+    final bloc = context.read<WirelessSettingsBloc>();
+
+    Navigator.push(
       context,
-      AppRoutes.wirelessSavedNetworkDetails,
-      arguments: {'network': network},
+      MaterialPageRoute(
+        builder: (context) => BlocProvider.value(
+          value: bloc, 
+          child: SavedNetworkDetails(network: network),
+        ),
+      ),
     );
   }
 
@@ -61,10 +67,10 @@ class _NetworkSettingsState extends State<NetworkSettings> {
   Widget build(BuildContext outerContext) {
     // Rename to outerContext
 
-    return BlocSelector<WirelessSettingsBloc, WirelessSettingsState, List<SavedWirelessNetwork>>(
+    return BlocSelector<WirelessSettingsBloc, WirelessSettingsState,
+        List<SavedWirelessNetwork>>(
       selector: (state) => state.allSavedNetworks,
       builder: (context, state) {
-       
         return Scaffold(
           appBar: PreferredSize(
               preferredSize: const Size.fromHeight(52),

--- a/apps/settings/lib/src/features/network/presentation/saved_network_details.dart
+++ b/apps/settings/lib/src/features/network/presentation/saved_network_details.dart
@@ -15,7 +15,11 @@ import 'package:mechanix_settings/src/commons/customWidgets/custom_text_button.d
 import 'package:mechanix_settings/src/commons/styles/color.dart';
 
 class SavedNetworkDetails extends StatefulWidget {
-  const SavedNetworkDetails({super.key});
+  const SavedNetworkDetails({
+    this.network,
+    super.key});
+    final SavedWirelessNetwork? network;
+    
 
   @override
   State<SavedNetworkDetails> createState() => _SavedNetworkDetailsState();
@@ -30,19 +34,14 @@ class _SavedNetworkDetailsState extends State<SavedNetworkDetails> {
 
   @override
   Widget build(BuildContext context) {
-    final args =
-        ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
-    final SavedWirelessNetwork network =
-        args['network'] as SavedWirelessNetwork;
-
     return BlocBuilder<WirelessSettingsBloc, WirelessSettingsState>(
       builder: (context, state) {
+        final network = widget.network!;
         final ssid = network.ssid;
         final security = (network.security != '' && network.security != null)
             ? network.security?.toUpperCase()
             : 'Open';
 
-        // todo : add ?
         void showDeleteDialog(String networkName) {
           showDialog(
             context: context,
@@ -94,14 +93,14 @@ class _SavedNetworkDetailsState extends State<SavedNetworkDetails> {
                   },
                   style: ButtonStyle(
                     iconColor: WidgetStateProperty.all(Colors.white),
-                    backgroundColor: WidgetStateProperty.all(Color(0xFFB71C1C)),
+                    backgroundColor: WidgetStateProperty.all(const Color(0xFFB71C1C)),
                     shape: WidgetStateProperty.all(
                       RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8.0),
                       ),
                     ),
-                    minimumSize: WidgetStateProperty.all(Size(32, 32)),
-                    fixedSize: WidgetStateProperty.all(Size(32, 32)),
+                    minimumSize: WidgetStateProperty.all(const Size(32, 32)),
+                    fixedSize: WidgetStateProperty.all(const Size(32, 32)),
                     padding: WidgetStateProperty.all(EdgeInsets.zero),
                   ),
                   icon: Center(

--- a/apps/settings/lib/src/features/network/presentation/wireless.dart
+++ b/apps/settings/lib/src/features/network/presentation/wireless.dart
@@ -12,6 +12,8 @@ import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_b
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_event.dart';
 import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_state.dart';
 import 'package:mechanix_settings/src/features/network/models/access_points.dart';
+import 'package:mechanix_settings/src/features/network/presentation/connect_secure_network.dart';
+import 'package:mechanix_settings/src/features/network/presentation/network_details.dart';
 import 'package:mechanix_settings/src/features/network/presentation/wireless_advance_settings.dart';
 import 'package:widgets/mechanix.dart';
 import 'package:widgets/widgets/listItems/simple_list_items_type.dart';
@@ -35,7 +37,8 @@ class _WirelessSettingsState extends State<WirelessSettings> {
       return Scaffold(
           appBar: PreferredSize(
               preferredSize: const Size.fromHeight(52),
-              child: const MechanixNavigationBar(title: "Network").padHorizontal(12)),
+              child: const MechanixNavigationBar(title: "Network")
+                  .padHorizontal(12)),
           body: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),
             physics: const BouncingScrollPhysics(),
@@ -202,42 +205,36 @@ void onNetworkTap(AccessPoints item, BuildContext context) {
         .read<ConnectNetworkBloc>()
         .add(ConnectToNetwork(item.nmAccessPoint));
   } else {
-    Navigator.pushNamed(
+    final bloc = context.read<ConnectNetworkBloc>();
+
+    Navigator.push(
       context,
-      AppRoutes.wirelessConnectSecureNetwork,
-      arguments: {'accessPoint': item.nmAccessPoint},
+      MaterialPageRoute(
+        builder: (context) => BlocProvider.value(
+          value: bloc,
+          child: ConnectSecureNetwork(accessPoint: item.nmAccessPoint),
+        ),
+      ),
     );
   }
 }
 
 void onInfoTap(AccessPoints item, BuildContext context) {
-  context.read<WirelessSettingsBloc>().add(SelectNetwork(item));
-  context
-      .read<WirelessSettingsBloc>()
-      .add(SelectNetworkPoint(item.nmAccessPoint));
-  Navigator.pushNamed(
+  final bloc = context.read<WirelessSettingsBloc>();
+
+  bloc.add(SelectNetwork(item));
+  bloc.add(SelectNetworkPoint(item.nmAccessPoint));
+
+  Navigator.push(
     context,
-    AppRoutes.wirelessNetworkDetails,
+    MaterialPageRoute(
+      builder: (context) => BlocProvider.value(
+        value: bloc, // reuse the existing bloc
+        child: const NetworkDetails(),
+      ),
+    ),
   );
 }
-
-// TODO: add this for router based bloc initialisation
-// void onInfoTap(AccessPoints item, BuildContext context) {
-//   final bloc = context.read<WirelessSettingsBloc>();
-
-//   bloc.add(SelectNetwork(item));
-//   bloc.add(SelectNetworkPoint(item.nmAccessPoint));
-
-//   Navigator.push(
-//     context,
-//     MaterialPageRoute(
-//       builder: (context) => BlocProvider.value(
-//         value: bloc, // reuse the existing bloc
-//         child: const NetworkDetails(),
-//       ),
-//     ),
-//   );
-// }
 
 String getNetworkIcon(String security, int? signalStrength) {
   // Set base icon based on WPA

--- a/apps/settings/lib/src/features/network/presentation/wireless_advance_settings.dart
+++ b/apps/settings/lib/src/features/network/presentation/wireless_advance_settings.dart
@@ -1,5 +1,7 @@
-import 'package:flutter/widgets.dart';
-import 'package:mechanix_settings/app_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mechanix_settings/src/features/network/blocs/wireless_settings_bloc.dart';
+import 'package:mechanix_settings/src/features/network/presentation/network_settings.dart';
 import 'package:widgets/mechanix.dart';
 import 'package:widgets/widgets/sectionList/section_list_items_type.dart';
 
@@ -27,7 +29,7 @@ class WirelessAdvanceSettings extends StatelessWidget {
         MechanixSectionList(title: 'Advanced Settings', sectionListItems: [
           SectionListItems(
             title: 'Manage Wireless',
-            onTap: () => onTap(context, AppRoutes.wirelessNetworkSettings),
+            onTap: () => onTap(context),
           )
         ]),
         // CustomLabelValue(
@@ -65,6 +67,16 @@ class WirelessAdvanceSettings extends StatelessWidget {
   }
 }
 
-void onTap(BuildContext context, String route) {
-  Navigator.pushNamed(context, route);
+void onTap(BuildContext context) {
+  final bloc = context.read<WirelessSettingsBloc>();
+
+  Navigator.push(
+    context,
+    MaterialPageRoute(
+      builder: (context) => BlocProvider.value(
+        value: bloc,
+        child: const NetworkSettings(),
+      ),
+    ),
+  );
 }


### PR DESCRIPTION
- fix: sync wireless bloc  with respect to its screen, it shall close bloc(& streams) while bloc no longer in use