### PR TITLE
feat(network): access point object path for list networks

### DIFF
--- a/dbus/freedesktop/networkmanager/src/interfaces/wireless.rs
+++ b/dbus/freedesktop/networkmanager/src/interfaces/wireless.rs
@@ -61,6 +61,7 @@ impl From<u32> for NMState {
 /// This struct holds low-level details as reported by the network hardware or driver.
 #[derive(Debug, Clone, Default)]
 pub struct RawAccessPointInfo {
+    pub object_path: String,
     /// Flags indicating access point capabilities.
     pub flags: u32,
     /// WPA-specific flags.
@@ -118,6 +119,7 @@ impl RawAccessPointInfo {
 /// High-level, user-friendly information about a Wireless network.
 #[derive(Debug, Clone)]
 pub struct WirelessNetworkInfo {
+    pub access_point_object_path: String,
     /// SSID (network name) as a UTF-8 string.
     pub ssid: String,
     /// Signal strength (0-100).
@@ -151,7 +153,7 @@ pub enum EventType {
 #[derive(Debug, Default)]
 pub struct AccessPointEvent {
     pub event_type: EventType,
-    pub access_point_path: String,
+    pub object_path: String,
     pub wireless_network_info: Option<WirelessNetworkInfo>,
 }
 

--- a/dbus/freedesktop/networkmanager/src/proxies/mod.rs
+++ b/dbus/freedesktop/networkmanager/src/proxies/mod.rs
@@ -451,6 +451,7 @@ impl NetworkManagerInterface for NetworkManagerProxy<'_> {
 
         let mut seen_ssids: Vec<String> = vec![];
         for access_point in access_points {
+            let object_path = access_point.to_string();
             // Create a proxy for the access point.
             let access_point_proxy =
                 match access_point::AccessPointProxy::new(&self.0.connection(), access_point).await
@@ -498,6 +499,7 @@ impl NetworkManagerInterface for NetworkManagerProxy<'_> {
             // Build the access point info struct.
             let raw_access_point_info = RawAccessPointInfo {
                 ssid: ssid.clone(),
+                object_path,
                 flags,
                 frequency,
                 bandwidth,

--- a/dbus/freedesktop/networkmanager/src/service.rs
+++ b/dbus/freedesktop/networkmanager/src/service.rs
@@ -7,9 +7,9 @@ use crate::interfaces::wireless::{
 };
 use crate::proxies::NetworkManagerProxy;
 use anyhow::Result;
+use futures::channel::mpsc;
 use futures::executor::ThreadPool;
 use futures::{FutureExt, StreamExt};
-use futures::channel::mpsc;
 use log::{debug, error, info};
 use std::sync::LazyLock;
 use zbus::Connection;
@@ -92,6 +92,7 @@ impl NetworkManagerService {
                 };
 
                 Ok(WirelessNetworkInfo {
+                    access_point_object_path: raw_ap.object_path,
                     ssid: raw_ap.ssid,
                     signal_strength,
                     security,
@@ -263,8 +264,8 @@ impl NetworkManagerService {
                                     continue; // Skip this item
                                 }
                             };
-                            let access_point_path = args.access_point.to_string();
-                            info!("access point added: {}", access_point_path);
+                            let access_point_object_path = args.access_point.to_string();
+                            info!("access point added: {}", access_point_object_path);
 
                             let raw_access_point_info = match proxy.get_access_point_info(&args.access_point).await {
                                 Ok(info) => info,
@@ -280,9 +281,10 @@ impl NetworkManagerService {
                             .then(|| "Protected".to_string()).unwrap_or("Open".to_string());
 
                             let access_point_event_info = AccessPointEvent {
-                                access_point_path,
+                                object_path: access_point_object_path.clone(),
                                 event_type: EventType::Added,
                                 wireless_network_info: Some(WirelessNetworkInfo {
+                                    access_point_object_path,
                                     ssid: raw_access_point_info.ssid,
                                     signal_strength: raw_access_point_info.strength,
                                     security: protected_or_open,
@@ -310,11 +312,11 @@ impl NetworkManagerService {
                                     continue; // Skip this item
                                 }
                             };
-                            let access_point_path = args.access_point.to_string();
-                            debug!("access point removed: {}", access_point_path);
+                            let object_path = args.access_point.to_string();
+                            debug!("access point removed: {}", object_path);
 
                             let access_point_event_info = AccessPointEvent {
-                                access_point_path,
+                                object_path,
                                 event_type: EventType::Removed,
                                 wireless_network_info: None,
                                 ..Default::default()

--- a/shell/crates/universal_search/Cargo.toml
+++ b/shell/crates/universal_search/Cargo.toml
@@ -15,6 +15,6 @@ gpui = { workspace = true }
 rust-embed = { workspace = true }
 anyhow = { workspace = true }
 commons = { path = "../commons" }
-mxsearch = { path = "/home/ojash/mecha/mechanix-gui/services/search/server" }
+mxsearch = { path = "../../../services/search/server" }
 unicode-segmentation = "1.12.0"
 freedesktop-icons = "0.4.0"


### PR DESCRIPTION
## Change
Access point object path added to list network payload,

## Why
In the GUI, the network list is mapped using SSIDs. When an access point is removed, the GUI must remove the corresponding SSID from the list. However, the remove event only provides the object path and does not contain SSID information.

By including the Access Point object path in the network list payload, the GUI can map each SSID to its corresponding object path. This allows the correct SSID to be identified and removed when an access point is removed.