### PR TITLE
fix(mxsearch): handled if path to watch doesn't exist

### DIFF
--- a/services/search/app_actions/src/service.rs
+++ b/services/search/app_actions/src/service.rs
@@ -268,7 +268,8 @@ impl AppActionsService {
         );
         let watch_path: PathBuf = self.config.schema_dir.clone().into();
         if !watch_path.exists() {
-            anyhow::bail!("Watch path does not exist: {}", watch_path.display());
+            error!("Watch path does not exist: {}", watch_path.display());
+            return Ok(());
         }
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(100);

--- a/services/search/apps/src/service.rs
+++ b/services/search/apps/src/service.rs
@@ -224,7 +224,8 @@ impl AppSearchService {
         );
         let watch_path: PathBuf = DESKTOP_APPS_DIR.into();
         if !watch_path.exists() {
-            anyhow::bail!("Watch path does not exist: {}", watch_path.display());
+            error!("Watch path does not exist: {}", watch_path.display());
+            return Ok(());
         }
 
         let (cmd_tx, mut cmd_rx) = mpsc::channel::<IndexCmd>(256);

--- a/services/search/files/src/service.rs
+++ b/services/search/files/src/service.rs
@@ -1,4 +1,4 @@
-use crate::utils::{FileMetadata, SchemaFields};
+    use crate::utils::{FileMetadata, SchemaFields};
 use crate::{utils, FilesConfig};
 use log::{debug, error, info, warn};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
@@ -365,7 +365,8 @@ impl FileSearchService {
 
         debug!("Watching path: {}", watch_path.display());
         if !watch_path.exists() {
-            anyhow::bail!("Watch path does not exist: {}", watch_path.display());
+            error!("Watch path does not exist: {}", watch_path.display());
+            return Ok(());
         }
 
         Self::index_existing_files(

--- a/services/search/server/settings.toml.example
+++ b/services/search/server/settings.toml.example
@@ -33,7 +33,7 @@ searchable_fields = [
 enable_search = true
 
 # Be careful watching "/home" recursively; consider narrowing later
-files_dir_to_watch = "/home/mecha/Downloads"
+files_dir_to_watch = "/home/mecha"
 
 index_dir = ".config/mxsearch/index/files"
 

--- a/services/search/sources/src/service.rs
+++ b/services/search/sources/src/service.rs
@@ -223,20 +223,6 @@ impl SourceSearchService {
         Ok(())
     }
 
-    pub async fn upsert_metadata(&mut self, payload: Vec<UpsertMetadata>) -> anyhow::Result<bool> {
-        debug!("Upserting metadata: {:?}", payload);
-        let ids: Vec<String> = payload.iter().map(|m| m.unique_id.clone()).collect();
-        if let Some(tx) = &self.cmd_tx {
-            tx.send(IndexCmd::RemoveByUniqueIds(ids, false)).await.ok();
-        }
-        if let Some(tx) = &self.cmd_tx {
-            tx.send(IndexCmd::Upsert(payload)).await.ok();
-            Ok(true)
-        } else {
-            anyhow::bail!("Indexer not running")
-        }
-    }
-
     pub async fn delete_by_ids(&mut self, ids: Vec<String>) -> anyhow::Result<bool> {
         debug!("delete by ids, length: {:?}", ids.len());
         if let Some(tx) = &self.cmd_tx {


### PR DESCRIPTION
## Fixes
1. If dir to watch is doesn't exist then returning Result instead of bail
