### PR TITLE
feat(lockscreen):set wallpaper with mxconf integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3990,6 +3990,7 @@ dependencies = [
  "dispatcher",
  "futures",
  "gpui",
+ "mxconf_dbus",
  "rust-embed",
  "settings",
  "shell_state",

--- a/shell/crates/dispatcher/src/lib.rs
+++ b/shell/crates/dispatcher/src/lib.rs
@@ -3,6 +3,7 @@ use futures::StreamExt;
 use gpui::*;
 use mxconf_dbus::watch_setting;
 use serde::{Deserialize, Serialize};
+use crate::Message::SetLockscreenWallpaper;
 
 #[derive(Clone)]
 pub struct Dispatcher(pub Sender<Message>, pub Receiver<Message>);
@@ -59,6 +60,7 @@ pub enum Message {
     SetKeyboardAlwayson(bool),
     ShowPowerOptions(bool),
     ShowLockscreen(bool),
+    SetLockscreenWallpaper(String),
     VolumeUp,
     VolumeDown,
     LaunchApp {
@@ -121,6 +123,19 @@ pub fn init(cx: &mut App) {
                                 }
                                 Err(err) => {
                                     eprintln!("Error while parsing theme colors: {}", err);
+                                }
+                            };
+                        }
+                        "settings.lockscreen.wallpaper" => {
+                            match tx
+                                .broadcast(SetLockscreenWallpaper(value))
+                                .await
+                            {
+                                Ok(_) => {
+                                    println!("lockscreen wallpaper message broadcasted");
+                                }
+                                Err(_) => {
+                                    println!("lockscreen wallpaper message broadcasted failed");
                                 }
                             };
                         }

--- a/shell/crates/lockscreen/Cargo.toml
+++ b/shell/crates/lockscreen/Cargo.toml
@@ -21,4 +21,4 @@ shell_state = { path = "../shell_state" }
 theme = { path = "../theme" }
 upower = { workspace = true }
 futures = "0.3.31"
-
+mxconf_dbus = { path = "../../../dbus/mechanix/mxconf" }

--- a/shell/crates/lockscreen/src/lib.rs
+++ b/shell/crates/lockscreen/src/lib.rs
@@ -53,7 +53,7 @@ pub fn run_app(cx: &mut App) {
                         // The value is usually stored under the key name or "value"
                         if let Some(wallpaper_path) = settings.get(setting_key) {
                             this.update(cx, |this, cx| {
-                                this.wallpaper_path = std::path::PathBuf::from(wallpaper_path);
+                                this.wallpaper_path = Some(std::path::PathBuf::from(wallpaper_path));
                                 cx.notify();
                             }).ok();
                         }
@@ -94,7 +94,7 @@ pub fn listen_dispatcher(cx: &mut Context<Lockscreen>) {
                 dispatcher::Message::SetLockscreenWallpaper(wallpaper) => {
                     println!("wallpaper to set in lockscreen: {}", wallpaper);
                     let _ = this.update(cx, |this, cx| {
-                        this.wallpaper_path = std::path::PathBuf::from(wallpaper);
+                        this.wallpaper_path = Some(std::path::PathBuf::from(wallpaper));
                         cx.notify();
                     });
                 }

--- a/shell/crates/lockscreen/src/lib.rs
+++ b/shell/crates/lockscreen/src/lib.rs
@@ -44,7 +44,22 @@ pub fn run_app(cx: &mut App) {
 
             cx.new(|cx| {
                 listen_dispatcher(cx);
-                Lockscreen::new(cx)
+                let lockscreen = Lockscreen::new(cx);
+                // Fetch the default wallpaper asynchronously
+                cx.spawn(async move |this: WeakEntity<Lockscreen> , cx| {
+                    let setting_key = "org.mechanix.desktop.settings.lockscreen.wallpaper";
+                    if let Ok(settings) = mxconf_dbus::get_setting(setting_key).await {
+                        // mxconf_dbus::get_setting returns a HashMap<String, String>
+                        // The value is usually stored under the key name or "value"
+                        if let Some(wallpaper_path) = settings.get(setting_key) {
+                            this.update(cx, |this, cx| {
+                                this.wallpaper_path = std::path::PathBuf::from(wallpaper_path);
+                                cx.notify();
+                            }).ok();
+                        }
+                    }
+                }).detach();
+                lockscreen
             })
         },
     )
@@ -73,6 +88,13 @@ pub fn listen_dispatcher(cx: &mut Context<Lockscreen>) {
                         if show {
                             this.reset(cx);
                         }
+                        cx.notify();
+                    });
+                }
+                dispatcher::Message::SetLockscreenWallpaper(wallpaper) => {
+                    println!("wallpaper to set in lockscreen: {}", wallpaper);
+                    let _ = this.update(cx, |this, cx| {
+                        this.wallpaper_path = std::path::PathBuf::from(wallpaper);
                         cx.notify();
                     });
                 }

--- a/shell/crates/lockscreen/src/ui/mod.rs
+++ b/shell/crates/lockscreen/src/ui/mod.rs
@@ -65,7 +65,7 @@ impl Lockscreen {
             drag_start_mouse_y: 0.0,
             position_y: 0.0,
             window_height: 0.0,
-            show: false,
+            show: true,
             show_arrow_prompt: false,
             wallpaper_path: None,
         }

--- a/shell/crates/lockscreen/src/ui/mod.rs
+++ b/shell/crates/lockscreen/src/ui/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use gpui::{prelude::FluentBuilder, *};
 use shell_state::ShellState;
 mod wallpaper;
@@ -41,6 +42,9 @@ const RIGHT_WEDGE_BOTTOM_LIMIT: f32 = 38.0;
 const LEFT_WEDGE_ICON_FADE_STRENGTH: f32 = 0.1;
 const RIGHT_WEDGE_ICON_FADE_STRENGTH: f32 = 0.8;
 
+// Wallpaper image path - use PNG for complex images (SVGs with masks/embedded images aren't fully supported)
+const DEFAULT_WALLPAPER_PATH: &str = "icons/lockscreen/wallpaper.png";
+
 pub struct Lockscreen {
     drag_offset: Option<f32>,
     drag_start_mouse_y: f32,
@@ -49,6 +53,7 @@ pub struct Lockscreen {
     window_height: f32,
     pub show: bool,
     show_arrow_prompt: bool,
+    pub wallpaper_path: PathBuf,
 }
 
 impl Lockscreen {
@@ -57,6 +62,7 @@ impl Lockscreen {
             cx.notify();
         })
         .detach();
+
         Self {
             drag_offset: None,
             drag_start_mouse_y: 0.0,
@@ -64,6 +70,7 @@ impl Lockscreen {
             window_height: 0.0,
             show: false,
             show_arrow_prompt: false,
+            wallpaper_path: std::path::PathBuf::from(DEFAULT_WALLPAPER_PATH),
         }
     }
 
@@ -142,6 +149,7 @@ impl Render for Lockscreen {
         let right_icon_opacity = 1.0 - fade_progress * RIGHT_WEDGE_ICON_FADE_STRENGTH;
         // Additional fade for lock + bell icons so they vanish at the fade threshold
         let lock_icon_fade = 1.0 - ((-panel_top) / LOCK_ICONS_FADE_THRESHOLD).max(0.0).min(1.0);
+        let wallpaper_path = self.wallpaper_path.clone();
 
         div().size_full().when(show, |this| {
             this.bg(overlay_color)
@@ -159,7 +167,7 @@ impl Render for Lockscreen {
                             div()
                                 .absolute()
                                 .inset_0()
-                                .child(wallpaper(size.width, px(panel_height))),
+                                .child(wallpaper(size.width, px(panel_height), wallpaper_path)),
                         )
                         // Content overlay
                         .child(

--- a/shell/crates/lockscreen/src/ui/mod.rs
+++ b/shell/crates/lockscreen/src/ui/mod.rs
@@ -42,9 +42,6 @@ const RIGHT_WEDGE_BOTTOM_LIMIT: f32 = 38.0;
 const LEFT_WEDGE_ICON_FADE_STRENGTH: f32 = 0.1;
 const RIGHT_WEDGE_ICON_FADE_STRENGTH: f32 = 0.8;
 
-// Wallpaper image path - use PNG for complex images (SVGs with masks/embedded images aren't fully supported)
-const DEFAULT_WALLPAPER_PATH: &str = "icons/lockscreen/wallpaper.png";
-
 pub struct Lockscreen {
     drag_offset: Option<f32>,
     drag_start_mouse_y: f32,
@@ -53,7 +50,7 @@ pub struct Lockscreen {
     window_height: f32,
     pub show: bool,
     show_arrow_prompt: bool,
-    pub wallpaper_path: PathBuf,
+    pub wallpaper_path: Option<PathBuf>,
 }
 
 impl Lockscreen {
@@ -70,7 +67,7 @@ impl Lockscreen {
             window_height: 0.0,
             show: false,
             show_arrow_prompt: false,
-            wallpaper_path: std::path::PathBuf::from(DEFAULT_WALLPAPER_PATH),
+            wallpaper_path: None,
         }
     }
 

--- a/shell/crates/lockscreen/src/ui/wallpaper.rs
+++ b/shell/crates/lockscreen/src/ui/wallpaper.rs
@@ -1,11 +1,9 @@
+use std::path::PathBuf;
 use gpui::*;
 
-// Wallpaper image path - use PNG for complex images (SVGs with masks/embedded images aren't fully supported)
-const WALLPAPER_PATH: &str = "icons/lockscreen/wallpaper.png";
-
 /// Creates a wallpaper element that fills the given dimensions
-pub fn wallpaper(width: Pixels, height: Pixels) -> impl IntoElement {
-    img(WALLPAPER_PATH)
+pub fn wallpaper(width: Pixels, height: Pixels, path: PathBuf) -> impl IntoElement {
+    img(path)
         .w(width)
         .h(height)
         .object_fit(ObjectFit::Cover)

--- a/shell/crates/lockscreen/src/ui/wallpaper.rs
+++ b/shell/crates/lockscreen/src/ui/wallpaper.rs
@@ -1,10 +1,15 @@
-use std::path::PathBuf;
 use gpui::*;
+use std::path::PathBuf;
 
+// Wallpaper image path - use PNG for complex images (SVGs with masks/embedded images aren't fully supported)
+const DEFAULT_WALLPAPER_PATH: &str = "icons/lockscreen/wallpaper.png";
 /// Creates a wallpaper element that fills the given dimensions
-pub fn wallpaper(width: Pixels, height: Pixels, path: PathBuf) -> impl IntoElement {
-    img(path)
-        .w(width)
-        .h(height)
-        .object_fit(ObjectFit::Cover)
+pub fn wallpaper(width: Pixels, height: Pixels, path: Option<PathBuf>) -> impl IntoElement {
+    match path {
+        Some(path) => img(path),
+        None => img(DEFAULT_WALLPAPER_PATH),
+    }
+    .w(width)
+    .h(height)
+    .object_fit(ObjectFit::Cover)
 }


### PR DESCRIPTION
## Changes
1. Dispatcher will listen on specific key for wallpaper change event, on change value will get updated in lock-screen
2. On load get and set default icon from mxconf
3. Fallback added as default icon from assets
4. Lockscreen will be shown once launcher is started