### PR TITLE
fix(files-app):  properties size value and date time format view

### DIFF
--- a/apps/files/lib/src/features/files/presentation/commons.dart
+++ b/apps/files/lib/src/features/files/presentation/commons.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:io' as io;
-import 'dart:math' as Math;
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:archive/archive.dart';
@@ -48,15 +48,21 @@ String formatModifiedTime(DateTime modified) {
 
 String formatDateTime(DateTime dateTime) {
   final formatter = DateFormat('dd-MM-yyyy, hh:mm a');
-  return formatter.format(dateTime).toLowerCase();
+  return formatter.format(dateTime).toUpperCase();
 }
 
-String formatBytes(int bytes, [int decimals = 2]) {
-  if (bytes <= 0) return "0 B";
-  const suffixes = ["B", "KB", "MB", "GB", "TB"];
-  final i = (bytes == 0) ? 0 : (Math.log(bytes) / Math.log(1024)).floor();
-  final size = bytes / Math.pow(1024, i);
-  return "${size.toStringAsFixed(decimals)} ${suffixes[i]}";
+String formatBytesDecimal(int bytes, {int decimals = 1}) {
+  if (bytes <= 0) return '0 B';
+
+  const base = 1000;
+  const suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+  final exponent =
+      (math.log(bytes) / math.log(base)).floor().clamp(0, suffixes.length - 1);
+
+  final size = bytes / math.pow(base, exponent);
+
+  return '${size.toStringAsFixed(decimals)} ${suffixes[exponent]}';
 }
 
 void _navigateToDirectory(

--- a/apps/files/lib/src/features/files/presentation/file_details_dialog.dart
+++ b/apps/files/lib/src/features/files/presentation/file_details_dialog.dart
@@ -40,7 +40,7 @@ class FileDetailsDialog extends StatelessWidget {
 
           final items = [
             buildDetailRow(context, "Type", details.type.toString()),
-            buildDetailRow(context, "Size", formatBytes(details.size)),
+            buildDetailRow(context, "Size", formatBytesDecimal(details.size)),
             buildDetailRow(
                 context, "Modified", formatDateTime(details.modified)),
             buildDetailRow(

--- a/apps/files/lib/src/features/files/presentation/move_file_dialog.dart
+++ b/apps/files/lib/src/features/files/presentation/move_file_dialog.dart
@@ -343,7 +343,7 @@ class MoveBottomSheetContentState extends State<MoveBottomSheetContent> {
               Expanded(
                 child: LayoutBuilder(
                   builder: (context, constraints) {
-                    final prefix = 'Moving ';
+                    final prefix = 'Moving';
                     final prefixStyle = regularStyle(context);
                     final labelStyle = boldStyle(context);
 


### PR DESCRIPTION
Update
----------------
1. Properties - size value and date time format view 
2. When moving file, removed extra space from text