### PR TITLE
fix(settings drawer): enable scroll in wireless/bluetooth modals and fix settings app launch

### DIFF
--- a/shell/crates/settings_drawer/src/ui/modals/bluetooth_modal.rs
+++ b/shell/crates/settings_drawer/src/ui/modals/bluetooth_modal.rs
@@ -13,6 +13,7 @@ use gpui::*;
 use icons::prelude::Icons;
 use shell_state::{BtMessage, ShellState};
 use theme::prelude::{AlphaExt, Theme};
+const BLUETOOTH_SETTINGS_PATH: &str = "/bluetooth";
 
 pub trait ScrollBehavior {
     fn scroll_offset(&self) -> Pixels;
@@ -142,7 +143,7 @@ impl SettingsDrawer {
                     .child(self.render_header_div(cx, "Bluetooth"))
                     .child(
                         div()
-                            .id("scrollable")
+                            .id("scrollable-bluetooth")
                             .flex_1()
                             .relative()
                             .overflow_hidden()
@@ -283,10 +284,16 @@ impl SettingsDrawer {
                                         if !is_connected && !is_paired {
                                             bluetooth_div =
                                                 bluetooth_div
-                                                    .on_click(cx.listener(move |_, _, _, _| {
+                                                    .on_click(cx.listener(move |this, _, _,  cx: &mut Context<Self>| {
                                                     println!(
                                                         "TODO: open portal/settings with params:"
                                                     );
+                                                     this.launch_app_with_path(
+                                                            this.settings_app_info.clone(),
+                                                            cx,
+                                                            BLUETOOTH_SETTINGS_PATH.to_string(),
+                                                        );
+                                                        cx.notify();
                                                 }));
                                         } else if !is_connected && is_paired {
                                             let address = bt.address.clone();
@@ -318,7 +325,7 @@ impl SettingsDrawer {
                                     })),
                             ),
                     )
-                    .child(self.render_settings_div(cx, "/bluetooth".to_string()));
+                    .child(self.render_settings_div(cx, BLUETOOTH_SETTINGS_PATH.to_string()));
                 w.upper_wing_size(Size::new(px(MODAL_WING_WIDTH), px(MODAL_WING_HEIGHT)));
                 w.border_width(px(1.0));
                 w.border_radius(px(8.0));

--- a/shell/crates/settings_drawer/src/ui/modals/display_modal.rs
+++ b/shell/crates/settings_drawer/src/ui/modals/display_modal.rs
@@ -4,7 +4,7 @@ use icons::prelude::SettingsDrawerIcons;
 use theme::prelude::{AlphaExt, Theme};
 
 use crate::ui::FINAL_MODAL_SIZE;
-use crate::ui::modals::{MODAL_HEADER_HEIGHT, MODAL_WING_HEIGHT, MODAL_WING_WIDTH};
+use crate::ui::modals::{MODAL_WING_HEIGHT, MODAL_WING_WIDTH};
 use crate::{
     prelude::*,
     ui::widgets::{Switch, SwitchSize},

--- a/shell/crates/settings_drawer/src/ui/modals/performance_modal.rs
+++ b/shell/crates/settings_drawer/src/ui/modals/performance_modal.rs
@@ -8,7 +8,7 @@ use crate::{
     prelude::*,
     ui::{
         FINAL_MODAL_SIZE,
-        modals::{MODAL_HEADER_HEIGHT, ROW_HEIGHT},
+        modals::ROW_HEIGHT,
     },
 };
 

--- a/shell/crates/settings_drawer/src/ui/modals/sound_modal.rs
+++ b/shell/crates/settings_drawer/src/ui/modals/sound_modal.rs
@@ -10,7 +10,7 @@ use crate::{
     prelude::*,
     ui::{
         FINAL_MODAL_SIZE,
-        modals::{MODAL_HEADER_HEIGHT, ROW_HEIGHT},
+        modals::ROW_HEIGHT,
     },
 };
 use crate::ui::modals::{MODAL_WING_HEIGHT, MODAL_WING_WIDTH};

--- a/shell/crates/settings_drawer/src/ui/modals/wireless_modal.rs
+++ b/shell/crates/settings_drawer/src/ui/modals/wireless_modal.rs
@@ -14,6 +14,7 @@ use crate::{
         modals::{MODAL_HEADER_HEIGHT, ROW_HEIGHT},
     },
 };
+const WIRELESS_SETTINGS_PATH: &str = "/wireless";
 
 pub trait ScrollBehavior {
     fn scroll_offset(&self) -> Pixels;
@@ -143,7 +144,7 @@ impl SettingsDrawer {
                     .child(self.render_header_div(cx, "Wireless"))
                     .child(
                         div()
-                            .id("scrollable")
+                            .id("scrollable-wireless")
                             .flex_1()
                             .relative()
                             .overflow_hidden()
@@ -263,11 +264,17 @@ impl SettingsDrawer {
 
                                             if !is_active && !is_known {
                                                 network_div = network_div.on_click(cx.listener(
-                                                    move |_, _, _, _| {
+                                                    move |this, _, _,  cx: &mut Context<Self>| {
                                                         println!(
                                                             "TODO: open settings for new network {:?} - {:?}",
                                                             ssid, is_known
                                                         );
+                                                        this.launch_app_with_path(
+                                                            this.settings_app_info.clone(),
+                                                            cx,
+                                                            WIRELESS_SETTINGS_PATH.to_string(),
+                                                        );
+                                                        cx.notify();
                                                     },
                                                 ));
                                             } else if !is_active && is_known {
@@ -300,7 +307,7 @@ impl SettingsDrawer {
                                     )),
                             ),
                     )
-                    .child(self.render_settings_div(cx, "/wireless".to_string()));
+                    .child(self.render_settings_div(cx, WIRELESS_SETTINGS_PATH.to_string()));
                 w.upper_wing_size(Size::new(px(MODAL_WING_WIDTH), px(MODAL_WING_HEIGHT)));
                 w.border_width(px(1.0));
                 w.border_radius(px(8.0));


### PR DESCRIPTION
### Issues

1. The Wireless and Bluetooth modal lists were not scrollable.
2. The Settings app did not launch from the Wireless and Bluetooth modals.

### Root Cause

 The `id(scrollable)` value is reserved for the default scrollable div behavior in GPUI.
This default behavior is not compatible with touch interfaces.

In our case, scrolling is handled manually, which caused a conflict with the reserved scrollable id.

### Fixes

1. Updated the id value from `scrollable` to `scrollable-<modal_name>` to avoid conflicts.
2. Added the required logic to correctly launch the Settings app from both modals.