### PR TITLE
fix(files-app): resolve PDFium symbol lookup error by setting pdfiumModulePath

### DIFF
--- a/apps/files/lib/app_config.dart
+++ b/apps/files/lib/app_config.dart
@@ -43,4 +43,6 @@ class AppConfig {
     final parsed = int.tryParse(value ?? '');
     return (parsed == null || parsed == 0) ? 50 : parsed;
   }
+
+  String get pdfiumModulePath => '/usr/lib64/libpdfium.so';
 }

--- a/apps/files/lib/src/features/preview/presentation/pdf_viewer.dart
+++ b/apps/files/lib/src/features/preview/presentation/pdf_viewer.dart
@@ -3,6 +3,7 @@ import 'dart:io' show FileSystemEntity, File;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mechanix_files/app_config.dart';
 import 'package:mechanix_files/src/commons/constants.dart';
 import 'package:mechanix_files/src/commons/customWidgets/middle_ellipsis_text.dart';
 import 'package:mechanix_files/src/commons/customWidgets/pressable_icon.dart';
@@ -58,6 +59,9 @@ class _PdfViewerPageState extends State<PdfViewerPage> {
   void initState() {
     super.initState();
 
+    // Set the path to the PDFium native library
+    Pdfrx.pdfiumModulePath = AppConfig().pdfiumModulePath;
+
     // Initialize text searcher and listen for changes in search results
     _searcher = PdfTextSearcher(_controller);
     _searcher.addListener(() {
@@ -66,15 +70,12 @@ class _PdfViewerPageState extends State<PdfViewerPage> {
         matches = _searcher.matches;
       });
     });
-
-    // _controller.addListener(_onPageChanged);
   }
 
   @override
   void dispose() {
     _hideBubbleTimer?.cancel();
     _pageBubbleOverlay?.remove();
-    // _controller.removeListener(_onPageChanged);
 
     _searcher.dispose();
     super.dispose();
@@ -224,20 +225,6 @@ class _PdfViewerPageState extends State<PdfViewerPage> {
       ),
       bottomNavigationBar: _buildBottomBar(context),
     );
-  }
-
-  void _onPageChanged() {
-    final page = _controller.pageNumber;
-    final count = _controller.pageCount ?? 0;
-
-    if (page == null || page == _currentPage) return;
-
-    setState(() {
-      _currentPage = page;
-      _pageCount = count;
-    });
-
-    _showPageBubble();
   }
 
   void _showPageBubble() {


### PR DESCRIPTION
**Issue**

PDF preview was failing with the runtime error:
`FPDF_InitLibraryWithConfig symbol not found in libflutter_engine.so`
This happened because pdfrx was attempting to resolve PDFium symbols from Flutter’s engine instead of the bundled libpdfium.so.

---

**Fix**

Explicitly configured the PDFium shared library path:
`Pdfrx.pdfiumModulePath `

This forces pdfrx to load the correct native PDFium binary.

---

**Result**
- PDF files now render correctly in preview
- No runtime symbol resolution errors