### PR TITLE
fix(settings-app): preserve wireless form state and correct private address switch UI

### DIFF
--- a/apps/settings/lib/src/features/network/presentation/add_network.dart
+++ b/apps/settings/lib/src/features/network/presentation/add_network.dart
@@ -63,6 +63,7 @@ class _AddNetworkState extends State<AddNetwork> {
                       MechanixTextInput.textInput(
                         hintText: 'Name',
                         isFormField: true,
+                        initialValue: state.username,
                         theme: MechanixTextInputThemeData(
                           widgetHeight: 58,
                           borderRadius: BorderRadius.circular(8),
@@ -107,6 +108,7 @@ class _AddNetworkState extends State<AddNetwork> {
                           return MechanixTextInput.password(
                             hintText: 'Enter Password',
                             isFormField: true,
+                            initialValue: state.password,
                             prefixIcon: IconWidget(
                               iconPath: Images.lockIcon,
                               iconWidth: 19,

--- a/apps/settings/lib/src/features/network/presentation/widgets/wireless_protocols_list.dart
+++ b/apps/settings/lib/src/features/network/presentation/widgets/wireless_protocols_list.dart
@@ -43,8 +43,9 @@ class _WirelessProtocolsListState extends State<WirelessProtocolsList> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               CustomTitle(
-                title:
-                    "Join ${widget.accessPoint != null ? '\'${utf8.decode(widget.accessPoint!.ssid)}\'' : ''}",
+                title: widget.accessPoint != null
+                    ? 'Join ${utf8.decode(widget.accessPoint!.ssid)}'
+                    : 'Security',
               ),
               MechanixSimpleList(listItems: [
                 SimpleListItems(

--- a/apps/settings/lib/src/features/network/presentation/widgets/wireless_protocols_list.dart
+++ b/apps/settings/lib/src/features/network/presentation/widgets/wireless_protocols_list.dart
@@ -26,6 +26,7 @@ class WirelessProtocolsList extends StatefulWidget {
 
 class _WirelessProtocolsListState extends State<WirelessProtocolsList> {
   WirelessProtocol? selectedValue;
+  bool isPrivateAddress = false;
 
   void onChange(SelectOption value) {
     setState(() {
@@ -47,16 +48,28 @@ class _WirelessProtocolsListState extends State<WirelessProtocolsList> {
               ),
               MechanixSimpleList(listItems: [
                 SimpleListItems(
-                    title: 'Private Wireless Address',
-                    trailing: MechanixSwitch(
-                        activeText: 'OFF',
-                        inactiveText: 'ON',
-                        style: MechanixSwitchStyle(
-                          activeTrackColor: context.secondaryContainer,
-                          inactiveTrackColor: context.secondaryContainer,
-                        ),
-                        value: true,
-                        onChanged: (v) {}))
+                  title: 'Private Wireless Address',
+                  titleTextStyle: const TextStyle(fontWeight: FontWeight.w700),
+                  onTap: () {
+                    setState(() {
+                      isPrivateAddress = !isPrivateAddress;
+                    });
+                  },
+                  trailing: MechanixSwitch(
+                    activeText: 'OFF',
+                    inactiveText: 'ON',
+                    style: MechanixSwitchStyle(
+                      activeTrackColor: context.secondaryContainer,
+                      inactiveTrackColor: context.secondaryContainer,
+                    ),
+                    value: isPrivateAddress,
+                    onChanged: (val) => {
+                      setState(() {
+                        isPrivateAddress = val;
+                      })
+                    },
+                  ),
+                ),
               ]),
               MechanixSelect(
                 value: selectedValue,


### PR DESCRIPTION
## Update
1.  Issue: When navigating back from the wireless protocols list, the previously entered values were not displayed.
    Fix: Added proper initial values to the network input fields to preserve state.

2. Issue: Toggling the switch did not correctly reflect the "Off" label in the UI.
     Fix: Updated the switch value handling logic.

3. Wireless protocol title condition incorrect
    Fix: Updated the conditional logic for rendering the correct title.