### PR TITLE
fix(upower): resolve clippy warnings and remove dead code

### DIFF
--- a/dbus/freedesktop/upower/src/proxies/mod.rs
+++ b/dbus/freedesktop/upower/src/proxies/mod.rs
@@ -186,7 +186,7 @@ impl<'a> UPowerInterface for DeviceProxy<'a> {
 }
 
 async fn get_device_proxy<'a>(cn: &'a Connection) -> Result<DeviceProxy<'a>, ProxyError> {
-    let proxy = match DeviceProxy::new(&cn).await {
+    let proxy = match DeviceProxy::new(cn).await {
         Ok(n) => n,
         Err(e) => {
             error!("failed to create Device proxy: {}", e);

--- a/dbus/freedesktop/upower/src/service.rs
+++ b/dbus/freedesktop/upower/src/service.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use futures::executor::ThreadPool;
 use futures::{SinkExt, StreamExt};
 use log::{error, info};
-use std::sync::{mpsc, LazyLock};
+use std::sync::LazyLock;
 use zbus::Connection;
 
 static THREAD_POOL: LazyLock<ThreadPool> =
@@ -39,12 +39,12 @@ impl UPowerService {
     pub async fn new() -> Result<Self, UpowerError> {
         let cn = Connection::system()
             .await
-            .map_err(|e| UpowerError::InitSystemBusError(format!("{}", e)))?;
+            .map_err(|e| UpowerError::InitSystemBusError(e.to_string()))?;
         let proxy = match DeviceProxy::new(&cn).await {
             Ok(n) => n,
             Err(e) => {
                 error!("failed to create Device proxy: {}", e);
-                return Err(UpowerError::CreateDeviceProxyError(format!("{}", e)));
+                return Err(UpowerError::CreateDeviceProxyError(e.to_string()));
             }
         };
         Ok(Self { proxy })
@@ -60,11 +60,7 @@ impl UPowerService {
         match self.proxy.get_battery_level().await {
             Ok(level) => {
                 // Convert the raw value to the BatteryLevel enum, or return a descriptive error.
-                let level = match BatteryLevel::try_from(level) {
-                    Ok(level) => level,
-                    Err(e) => return Err(UpowerError::InvalidBatteryLevel(e.to_string())),
-                };
-                Ok(level)
+                Ok(BatteryLevel::from(level))
             }
             Err(e) => Err(UpowerError::from(e)),
         }
@@ -88,7 +84,7 @@ impl UPowerService {
     /// * `Ok(f64)` containing the battery percentage.
     /// * Propagates any error from the underlying interface.
     pub async fn get_percentage(&self) -> Result<f64, UpowerError> {
-        self.proxy.get_percentage().await.map_err(|e| e.into())
+        self.proxy.get_percentage().await.map_err(Into::into)
     }
 
     /// Asynchronously retrieves the current battery status as a [`BatteryState`] enum.
@@ -101,11 +97,7 @@ impl UPowerService {
         match self.proxy.get_state().await {
             Ok(state) => {
                 // Convert the raw value to the BatteryState enum or return a descriptive error.
-                let state = match BatteryState::try_from(state) {
-                    Ok(state) => state,
-                    Err(_e) => return Err(UpowerError::InvalidBatteryState.into()),
-                };
-                Ok(state)
+                Ok(BatteryState::from(state))
             }
             Err(e) => Err(e.into()),
         }
@@ -123,7 +115,7 @@ impl UPowerService {
                 // Convert the raw value to the PowerSourceType enum, or return a descriptive error.
                 let type_ = match PowerSourceType::try_from(type_) {
                     Ok(type_) => type_,
-                    Err(_e) => return Err(UpowerError::InvalidPowerSourceType.into()),
+                    Err(_e) => return Err(UpowerError::InvalidPowerSourceType),
                 };
                 Ok(type_)
             }
@@ -147,11 +139,6 @@ impl UPowerService {
                                     continue;
                                 }
                             };
-                            // let state = BatteryState::from(state);
-                            // if let Err(e) = sender.send(state) {
-                            //     error!("failed to send battery state: {}", e);
-                            //     continue;
-                            // }
                         }
                     }
                 }
@@ -178,10 +165,6 @@ impl UPowerService {
                                     continue;
                                 }
                             };
-                            // if let Err(e) = sender.send(state) {
-                            //     error!("failed to send device percentage: {}", e);
-                            //     continue;
-                            // }
                         }
                     }
                 }
@@ -210,156 +193,14 @@ impl UPowerService {
                                     continue;
                                 }
                             };
-                            // if let Err(e) = sender.send(state) {
-                            //     error!("failed to send battery level: {}", e);
-                            //     continue;
-                            // }
                         }
                     }
                 }
                 Err(e) => {
-                    error!("Failed to stream to device percentage: {}", e);
+                    error!("Failed to stream battery level events: {}", e);
                 }
             }
         });
         receiver
     }
 }
-
-/*
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::proxies::ProxyError;
-    use anyhow::Result;
-    use mockall::mock;
-    use zbus::proxy::PropertyStream;
-
-    // Mock the UpowerInterface trait
-    mock! {
-        pub UpowerInterface {}
-
-        #[async_trait::async_trait]
-        impl UPowerInterface for UpowerInterface {
-            async fn get_battery_level(&self) -> Result<u32, ProxyError>;
-            async fn get_warning_level(&self) -> Result<u32, ProxyError>;
-            async fn get_percentage(&self) -> Result<f64, ProxyError>;
-            async fn get_state(&self) -> Result<u32, ProxyError>;
-            async fn get_power_source_type(&self) -> Result<u32, ProxyError>;
-            async fn stream_device_state(&self) -> Result<PropertyStream<u32>, ProxyError>;
-        }
-    }
-
-    #[tokio::test]
-    async fn test_get_battery_level_success() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_battery_level().returning(|| Ok(3)); // 3 maps to BatteryLevel::Low
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_battery_level().await;
-        assert_eq!(result.unwrap(), BatteryLevel::Low);
-    }
-
-    #[tokio::test]
-    async fn test_get_battery_level_invalid_enum() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_battery_level().returning(|| Ok(42)); // 42 is not a valid BatteryLevel
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_battery_level().await;
-        assert!(matches!(
-            result.unwrap_err(),
-            UpowerError::InvalidBatteryLevel(_)
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_get_battery_level_error() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_battery_level()
-            .returning(|| Err(ProxyError::DbusCallFailed("dbus error".into())));
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_battery_level().await;
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "dbus error");
-    }
-
-    #[tokio::test]
-    async fn test_get_warning_level_success() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_warning_level().returning(|| Ok(2)); // Assume 2 is a valid WarningLevel
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_warning_level().await;
-        assert_eq!(result.unwrap(), WarningLevel::from(2));
-    }
-
-    #[tokio::test]
-    async fn test_get_warning_level_error() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_warning_level()
-            .returning(|| Err(ProxyError::DbusCallFailed("dbus error".into())));
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_warning_level().await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_get_percentage_success() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_percentage().returning(|| Ok(77.7)); // Assume 77.7 is a valid percentage
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_percentage().await;
-        assert_eq!(result.unwrap(), 77.7);
-    }
-
-    #[tokio::test]
-    async fn test_get_state_success() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_state().returning(|| Ok(2)); // 2 maps to some BatteryState
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_state().await;
-        assert_eq!(result.unwrap(), BatteryState::try_from(2).unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_get_state_invalid_enum() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_state().returning(|| Ok(99)); // Invalid BatteryState
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_state().await;
-        assert!(matches!(
-            result.unwrap_err(),
-            UpowerError::InvalidBatteryState
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_get_power_source_type_success() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_power_source_type().returning(|| Ok(2)); // 2 maps to Battery
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_power_source_type().await;
-        assert_eq!(result.unwrap(), PowerSourceType::try_from(2).unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_get_power_source_type_invalid_enum() {
-        let mut mock = MockUpowerInterface::new();
-        mock.expect_get_power_source_type().returning(|| Ok(99)); // Invalid PowerSourceType
-
-        let service = UpowerService::new().await.unwrap();
-        let result = service.get_power_source_type().await;
-        assert!(matches!(
-            result.unwrap_err(),
-            UpowerError::InvalidPowerSourceType
-        ));
-    }
-}
-*/


### PR DESCRIPTION
Clean up the upower crate to pass cargo clippy with zero warnings.

- Replace fallible conversions (try_from) with infallible From impls where the conversion cannot fail
- Use idiomatic e.to_string() instead of format!("{}", e)
- Remove unused import and unnecessary .into() calls
- Remove commented-out code blocks and dead test module
- Fix copy-paste error in stream_battery_level log message

Verified: `cargo clippy -p upower` passes clean.